### PR TITLE
Fix grammar in Terminal docs

### DIFF
--- a/en/topics/terminal/notifications.md
+++ b/en/topics/terminal/notifications.md
@@ -9,11 +9,11 @@ Notifications can be of the following form:
 - **Window** \- a small pop\-up window with a message will appear in the corner of the screen.
 - **Music** \- the music will be played.
 - **SMS** \- the message will be sent by SMS.
-- **Email** \- the message will be sent to the e\-mail.
-- **Voice** \- the message will be spoken by the computer generated voice.
+- **Email** \- the message will be sent by email.
+- **Voice** \- the message will be spoken by the computer-generated voice.
 - **Log** \- the message will be sent to the [Logs](user_interface/logs.md).
 - **Disabled** \- the notification will not be displayed.
 
 To set a notification, you have to click the ![Designer Creation tool 00](../../images/designer_creation_tool_00.png) button in the notification panel ([Notification panel](notifications/notification_panel.md)) or click the ![Designer Alert Bell](../../images/designer_alert_bell.png) button directly in the panels that support notifications.
 
-For information on how to configure notifications, see [Notifications setup](notifications/notifications_setup.md) section.
+For information on how to configure notifications, see the [Notifications setup](notifications/notifications_setup.md) section.

--- a/en/topics/terminal/notifications/notifications_setup.md
+++ b/en/topics/terminal/notifications/notifications_setup.md
@@ -4,14 +4,14 @@ To set a notification, you have to click the ![Designer Creation tool 00](../../
 
 ![Designer Notifications Setting](../../../images/designer_notifications_setting.png)
 
-Notification can be configure for change of the following data types: Portfolio, Customer code, Broker, Depository, Server time, Trade, Data type, Cancellation, Order ID, Order ID (string), Order ID (board), Derivative, Derivative (string), Price, Volume (order), Volume (trade), Visible volume, Direction, Remainder, Order type, Status, Comment, Message to order, System order, Order expiration time, Execution condition, Order ID, Order ID (string), Price, Trade initiator, Open interest, Error, Condition, Uptrend, Commission, Delay, Slippage, ID (user), Currency, P\/L, Position, Market Maker.
+Notifications can be configured for changes in the following data types: Portfolio, Customer code, Broker, Depository, Server time, Trade, Data type, Cancellation, Order ID, Order ID (string), Order ID (board), Derivative, Derivative (string), Price, Volume (order), Volume (trade), Visible volume, Direction, Remainder, Order type, Status, Comment, Message to order, System order, Order expiration time, Execution condition, Order ID, Order ID (string), Price, Trade initiator, Open interest, Error, Condition, Uptrend, Commission, Delay, Slippage, ID (user), Currency, P\/L, Position, Market Maker.
 
 Notifications can be of the following form:
 
-- **Window** – small pop\-up window with a message will appear the screen corner.
+- **Window** – a small pop\-up window with a message will appear in the corner of the screen.
 - **Melody** – a melody will be played.
-- **SMS** – message will be sent using sms.
-- **Email** – message will be emailed.
-- **Speech** – message will be spoken by the computer generated voice.
-- **Log** – message will be sent to the Designer logs window.
-- **Off** – notification will not be shown.
+- **SMS** – a message will be sent via SMS.
+- **Email** – the message will be emailed.
+- **Speech** – the message will be spoken by a computer-generated voice.
+- **Log** – the message will be sent to the Designer logs window.
+- **Off** – the notification will not be shown.

--- a/en/topics/terminal/quick_start.md
+++ b/en/topics/terminal/quick_start.md
@@ -8,7 +8,7 @@ You must select the start mode and click **OK**.
 
 After selecting the start mode, the terminal window opens with the default set of components.
 
-Let's go to the connection settings and select the required connection. How to setup the connection is described in the [Connection settings](connection_settings.md) section.
+Let's go to the connection settings and select the required connection. How to set up the connection is described in the [Connection settings](connection_settings.md) section.
 
 ![Terminal Quick start 011](../../images/terminal_quick_start_011.png)
 
@@ -18,15 +18,15 @@ Clicking the **Add** ![Designer Creation tool 00](../../images/designer_creation
 
 ![Terminal Quick start 01](../../images/terminal_quick_start_01.png)
 
-Clicking the **Add** ![Designer Creation tool 00](../../images/designer_creation_tool_00.png) button on the Instrument panel, we add the instruments we want to watch. Here, the best price data will be displayed. For more information on how to work with the Instrument panel, see the [Instruments](user_interface/components/instruments.md) section.
+Clicking the **Add** ![Designer Creation tool 00](../../images/designer_creation_tool_00.png) button on the Instrument panel adds the instruments you want to watch. The best price data will be displayed here. For more information on how to work with the Instrument panel, see the [Instruments](user_interface/components/instruments.md) section.
 
 ![Terminal Quick start 02](../../images/terminal_quick_start_02.png)
 
-In the order book, after clicking the **Settings** ![Designer Schedule 01](../../images/designer_schedule_01.png) button, a panel appears, in which we will indicate the **Instrument** and the **Portfolio** by which the trades will take place. Also adjust the order book depth. For more information on how to work with an order book, see the [Order book](user_interface/components/order_book.md) section.
+In the order book, after clicking the **Settings** ![Designer Schedule 01](../../images/designer_schedule_01.png) button, a panel appears where you can specify the **Instrument** and the **Portfolio** for the trades. Here you can also adjust the order book depth. For more information on how to work with an order book, see the [Order book](user_interface/components/order_book.md) section.
 
 ![Terminal Quick start 03](../../images/terminal_quick_start_03.png)
 
-Let’s register the first few orders. Orders can be registered either by clicking the **Buy\/Sell** buttons or by clicking the cell of the **Bid\/Offer** columns in the order book itself. The order panel will display all our orders. When you right click with the mouse button on the order, you will see a panel with which you can register submit a new order, cancel or change the selected order. For more information on how to work with the order panel, see the [Orders](user_interface/components/orders.md) section.
+Let’s register the first few orders. Orders can be registered either by clicking the **Buy/Sell** buttons or by clicking the cells in the **Bid/Offer** columns of the order book itself. The order panel displays all your orders. When you right-click an order, you will see a panel that lets you submit a new order, cancel, or change the selected order. For more information on how to work with the order panel, see the [Orders](user_interface/components/orders.md) section.
 
 ![Terminal Quick start 04](../../images/terminal_quick_start_04.png)
 

--- a/en/topics/terminal/user_interface/components/instruments.md
+++ b/en/topics/terminal/user_interface/components/instruments.md
@@ -4,7 +4,7 @@ The **Instruments** component is a table with instruments that displays informat
 
 To add a new instrument, click the ![Designer Creation tool 00](../../../../images/designer_creation_tool_00.png) button. 
 
-t is also possible to configure notifications for events of the selected instruments \- [Notification settings](../../notifications.md).
+It is also possible to configure notifications for events of the selected instruments \- [Notification settings](../../notifications.md).
 
 ![Terminal securities 00](../../../../images/terminal_securities_00.png)
 

--- a/en/topics/terminal/user_interface/components/news.md
+++ b/en/topics/terminal/user_interface/components/news.md
@@ -2,9 +2,9 @@
 
 The **News** component displays news received from connections.
 
-To start receiving news, click the **Receive news** button
+To start receiving news, click the **Receive news** button.
 
-The News panel has the ability to configure notifications for selected events – [Notification settings](../../notifications.md).
+The News panel allows you to configure notifications for selected events – see [Notification settings](../../notifications.md).
 
 ![Terminal news 00](../../../../images/terminal_news_00.png)
 

--- a/en/topics/terminal/user_interface/components/order_book.md
+++ b/en/topics/terminal/user_interface/components/order_book.md
@@ -4,7 +4,7 @@ The **Order book** component is a table of limit orders for the purchase and sal
 
 When you click the settings ![Designer The quick access toolbar 02](../../../../images/designer_quick_access_toolbar_02.png) button, a panel appears in which you can set the necessary instrument and portfolio, as well as configure the order book display options. 
 
-Orders can be registered either by clicking the **Buy\/Sell** buttons or by clicking the cell of the **Bid\/Offer** columns in the order book itself.
+Orders can be registered either by clicking the **Buy/Sell** buttons or by clicking the cells in the **Bid/Offer** columns in the order book itself.
 
 ![Terminal Panel Market Depth](../../../../images/terminal_panel_market_depth.png)
 


### PR DESCRIPTION
## Summary
- improve grammar for all Terminal markdown files
- adjust quick start instructions about orders
- fix description in Notifications pages
- clarify news and order book notes

## Testing
- `python -m py_compile increase_links.py`


------
https://chatgpt.com/codex/tasks/task_e_68434ca1a86483239ac7ba4e4176656a