### PR TITLE
Fix grammar in shell docs

### DIFF
--- a/en/topics/shell/connections_settings.md
+++ b/en/topics/shell/connections_settings.md
@@ -1,5 +1,3 @@
 # Connections settings
 
-See 
-
-[Connections settings](../designer/connections_settings.md)
+See [Connections settings](../designer/connections_settings.md).

--- a/en/topics/shell/connections_settings/connector_settings.md
+++ b/en/topics/shell/connections_settings/connector_settings.md
@@ -1,5 +1,3 @@
 # Connector settings
 
-See 
-
-[Connectors settings](../../designer/connections_settings/connectors_settings.md)
+See [Connectors settings](../../designer/connections_settings/connectors_settings.md).

--- a/en/topics/shell/create_strategy.md
+++ b/en/topics/shell/create_strategy.md
@@ -4,7 +4,7 @@ To create your own strategy, create a folder for your strategy in the Strategies
 
 ![Shell custom strategy 00](../../images/shell_custom_strategy_00.png)
 
-Using the example of SmaStrategy, you need to create the strategy itself.
+Using SmaStrategy as an example, create the strategy itself.
 
 If you need to add your own testing or monitoring panel for a strategy, then the strategy must implement the IHaveTestControl and IHaveMonitoringControl interfaces, respectively.
 
@@ -13,7 +13,7 @@ public class SmaStrategy : Strategy, IHaveMonitoringControl, IHaveTestControl
 	{
 	...
 		#region MonitoringControl
-		public BaseStudioControl AddMonitorigPanel()
+                public BaseStudioControl AddMonitoringPanel()
 		{
 			var usercontrol = new SmaMonitoringControl();
 			usercontrol.Init(this);
@@ -33,7 +33,7 @@ public class SmaStrategy : Strategy, IHaveMonitoringControl, IHaveTestControl
 		
 ```
 
-And you also need to create the panels themselves. How to build your own testing or monitoring panel is described in [Create strategy panel](create_strategy_panel.md).
+You also need to create the panels themselves. How to build your own testing or monitoring panel is described in [Create strategy panel](create_strategy_panel.md).
 
 > [!TIP]
 > If there are enough testing or monitoring panels for the strategy, which are used for default strategies, then you do not need to implement the IHaveTestControl and IHaveMonitoringControl interfaces. Shell will run the default testing or monitoring panels by itself. 
@@ -73,7 +73,7 @@ public class SmaStrategy : Strategy, IHaveMonitoringControl, IHaveTestControl
 		
 ```
 
-To save additional fields, you must override the **Load** and **Save** methods
+To save additional fields, you must override the **Load** and **Save** methods.
 
 ```cs
 public class SmaStrategy : Strategy, IHaveMonitoringControl, IHaveTestControl

--- a/en/topics/shell/create_strategy_panel.md
+++ b/en/topics/shell/create_strategy_panel.md
@@ -1,6 +1,6 @@
 # Create strategy panel
 
-Own panels are a special control created by S\# to facilitate work with DevExpress elements.
+Custom panels are special controls created by S\# to facilitate working with DevExpress elements.
 
 First, you need to create a simple UserControl in the XAML folder of your strategy.
 
@@ -8,7 +8,7 @@ First, you need to create a simple UserControl in the XAML folder of your strate
 
 ![Shell custom strategy panel 01](../../images/shell_custom_strategy_panel_01.png)
 
-Replace UserControl with controls:BaseStudioControl
+Replace `UserControl` with `controls:BaseStudioControl`.
 
 ```xaml
 <controls:BaseStudioControl>
@@ -17,7 +17,7 @@ Replace UserControl with controls:BaseStudioControl
 	  				
 ```
 
-And implement your own panel logic by analogy with the existing strategy panels.
+Then implement your own panel logic by analogy with the existing strategy panels.
 
 In order for the [Real\-time](user_interface/real_time.md) panel to see the strategy in your panel, your strategy must be set as a property:
 

--- a/en/topics/shell/installing_shell.md
+++ b/en/topics/shell/installing_shell.md
@@ -1,3 +1,3 @@
 # Installing Shell
 
-[Install and remove apps](../installer/install_and_remove_apps.md)
+[Install and remove apps](../installer/install_and_remove_apps.md).

--- a/en/topics/shell/quick_start.md
+++ b/en/topics/shell/quick_start.md
@@ -2,33 +2,33 @@
 
 [Shell](../shell.md) \- \- is focused on programming in [C\#](https://en.wikipedia.org/wiki/C_Sharp_(programming_language)) language in Visual Studio environment or similar.
 
-When you start the [Shell](../shell.md) project, the solution explorer displays the Shell project:
+When you start the [Shell](../shell.md) project, the Solution Explorer displays the Shell project:
 
 ![Shell Quick start 00](../../images/shell_quick_start_00.png)
 
 The **Strategies** folder contains three strategies included in [Shell](../shell.md), a shell for default strategies, as well as some auxiliary interfaces.
 
-The project can be launched without preliminary preparation and see its operation on strategies that are already included in [Shell](../shell.md).
+The project can be launched without any preliminary preparation to see how it operates on the strategies already included in [Shell](../shell.md).
 
 After launch, we will see a window like this:
 
 ![Shell Quick start 01](../../images/shell_quick_start_01.png)
 
-The connection settings, the connection itself buttons, and the save button for the current Shell configuration are located at the top of the screen. There are also the main tabs.
+The connection settings and connection buttons, as well as the save button for the current Shell configuration, are located at the top of the screen. The main tabs are also located there.
 
 Go to the connection settings and select the necessary connection. How to set up a connection is described in [Connections settings](connections_settings.md).
 
 The next step is to connect by clicking the **Connect** button ![Designer The quick access toolbar 00](../../images/designer_quick_access_toolbar_00.png).
 
-After connection, on the[Common](user_interface/common.md) tab, you can see the portfolios, securities, orders and own trades that were received from the connection.
+After connecting, on the [Common](user_interface/common.md) tab, you can see the portfolios, securities, orders, and own trades received from the connection.
 
 ![Shell Quick start 02](../../images/shell_quick_start_02.png)
 
-Go to the Real\-time tab, click the **Add** ![Designer Creation tool 00](../../images/designer_creation_tool_00.png) button to add a strategy to start trading.
+Go to the Real\-time tab and click the **Add** ![Designer Creation tool 00](../../images/designer_creation_tool_00.png) button to add a strategy for trading.
 
 ![Shell Quick start 03](../../images/shell_quick_start_03.png)
 
-Once the strategy is added, it is necessary to fill in its basic parameters such as **Security**, **Portfolio**, etc. To start it is necessary to click the Start strategy button.
+Once the strategy is added, fill in its basic parameters such as **Security**, **Portfolio**, etc. Click the Start strategy button to launch it.
 
 ![Shell Quick start 04](../../images/shell_quick_start_04.png)
 

--- a/en/topics/shell/run_strategies_from_designer.md
+++ b/en/topics/shell/run_strategies_from_designer.md
@@ -2,7 +2,7 @@
 
 [Shell](../shell.md) can run strategies created in [Designer](../designer.md).
 
-To launch a strategy created in [Designer](../designer.md), you need to select it on the [Real\-time](user_interface/real_time.md) select tab and click the **Add Designer strategy** button. In the window that appears, select the strategy file exported from [Designer](../designer.md). 
+To launch a strategy created in [Designer](../designer.md), select it on the [Real\-time](user_interface/real_time.md) tab and click the **Add Designer strategy** button. In the window that appears, choose the strategy file exported from [Designer](../designer.md).
 
 ![Shell run Designer strategy 00](../../images/shell_run_designer_strategy_00.png)
 
@@ -10,7 +10,7 @@ After that, it will appear in the list of available strategies.
 
 ![Shell run Designer strategy 01](../../images/shell_run_designer_strategy_01.png)
 
-By selecting the added strategy, you can set the necessary parameters and launch it in the trade.
+By selecting the added strategy, you can set the necessary parameters and launch it for trading.
 
 ![Shell run Designer strategy 02](../../images/shell_run_designer_strategy_02.png)
 

--- a/en/topics/shell/user_interface/common.md
+++ b/en/topics/shell/user_interface/common.md
@@ -1,6 +1,6 @@
 # Common
 
-The [Common]() tab allows you to view general information on portfolios, orders, trades, securities. Also here you can set the theme of the [Shell](../../shell.md) interface.
+The [Common]() tab allows you to view general information on portfolios, orders, trades, and securities. You can also set the theme of the [Shell](../../shell.md) interface here.
 
 ![Shell Common 00](../../../images/shell_common_00.png)
 

--- a/en/topics/shell/user_interface/emulation.md
+++ b/en/topics/shell/user_interface/emulation.md
@@ -1,12 +1,12 @@
 # Emulation
 
-The [Emulation]() tab allows to test strategies on historical data.
+The [Emulation]() tab allows you to test strategies on historical data.
 
 ![Shell emulation 00](../../../images/shell_emulation_00.png)
 
 By clicking the **Add** ![Designer Creation tool 00](../../../images/designer_creation_tool_00.png) button, you can add a strategy for testing. Each added strategy is opened on an individual tab.
 
-Individual strategy tab has extensive information on the strategy, statistics, list of registered orders and trades of the strategy, etc. On this tab, you can configure testing parameters, the path to historical data, the start and end dates of testing, the format of the historical data storage. 
+An individual strategy tab has extensive information about the strategy, statistics, a list of registered orders and trades of the strategy, etc. On this tab, you can configure testing parameters, the path to historical data, the start and end dates of testing, and the format of the historical data storage.
 
 ## Recommended content
 

--- a/en/topics/shell/user_interface/real_time.md
+++ b/en/topics/shell/user_interface/real_time.md
@@ -1,6 +1,6 @@
 # Real\-time
 
-The [Real\-time]() tab allows to manage strategies launched in trading.
+The [Real\-time]() tab allows you to manage strategies launched in trading.
 
 ![Shell realtime 00](../../../images/shell_realtime_00.png)
 

--- a/en/topics/shell/user_interface/remotemanager.md
+++ b/en/topics/shell/user_interface/remotemanager.md
@@ -14,15 +14,15 @@ Then you need to enable the **server mode**.
 
 You can now connect to Shell from another Shell.
 
-To do this, you need to run **another Shell**. In it go to the connection settings.
+To do this, you need to run **another Shell**. In it, go to the connection settings.
 
 ![Shell RemoteManager 03](../../../images/shell_remotemanager_03.png)
 
-In the window that opens, set up Fix connection
+In the window that opens, set up the FIX connection
 
 ![Shell RemoteManager 04](../../../images/shell_remotemanager_04.png)
 
-Then press the connection button
+Then press the Connect button
 
 ![Shell RemoteManager 05](../../../images/shell_remotemanager_05.png)
 
@@ -34,7 +34,7 @@ By clicking the Add button, you can add another strategy to trade.
 
 ![Shell RemoteManager 07](../../../images/shell_remotemanager_07.png)
 
-Because Shell client supports multiple servers. So when choosing to add a strategy, you must select the server on the left, and on the right there will be all strategies available on the server.
+Because the Shell client supports multiple servers, when adding a strategy you must select the server on the left. All strategies available on the server will appear on the right.
 
 ![Shell RemoteManager 08](../../../images/shell_remotemanager_08.png)
 
@@ -54,7 +54,7 @@ If the strategy has a command other than Start\/Stop, then to apply it you must 
 
 And click the send command button.
 
-To set your team in the strategy, you need to override the [Strategy.ApplyCommand](xref:StockSharp.Algo.Strategies.Strategy.ApplyCommand(StockSharp.Messages.CommandMessage))**(**[StockSharp.Messages.CommandMessage](xref:StockSharp.Messages.CommandMessage) cmdMsg **)** method.
+To set your command in the strategy, you need to override the [Strategy.ApplyCommand](xref:StockSharp.Algo.Strategies.Strategy.ApplyCommand(StockSharp.Messages.CommandMessage))**(**[StockSharp.Messages.CommandMessage](xref:StockSharp.Messages.CommandMessage) cmdMsg **)** method.
 
 ```cs
 public virtual void ApplyCommand(CommandMessage cmdMsg)


### PR DESCRIPTION
## Summary
- correct grammar and typos in Shell documentation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68434cbe632c832386ff0c2372ac84f7