### PR TITLE
Fix English grammar in Hydra docs

### DIFF
--- a/en/topics/hydra/instruments_and_boards/boards.md
+++ b/en/topics/hydra/instruments_and_boards/boards.md
@@ -1,7 +1,7 @@
 # Boards
 
-**Common** tab, **Boards** button.
+On the **Common** tab, click the **Boards** button.
 
-Here it is possible to view basic information about the trading boards, as well as set the time zone and the schedule of their work.
+Here you can view basic information about trading boards and set their time zone and working schedule.
 
 ![hydra boards](../../../images/hydra_boards.png)

--- a/en/topics/hydra/instruments_and_boards/continuous_futures.md
+++ b/en/topics/hydra/instruments_and_boards/continuous_futures.md
@@ -1,14 +1,14 @@
 # Continuous futures
 
-The [Hydra](../../hydra.md) program allows the user to glue different types of market data on different contracts into one continuous instrument.
+The [Hydra](../../hydra.md) program allows the user to combine different types of market data from various contracts into a single continuous instrument.
 
-To do this, on the **Common** tab, select **Securities**, the **All securities** tab will appear. Before gluing the data, you need to check what market data is available. For this, the path is selected where the data is located and the instruments that are supposed to be glued are viewed in turn. If there are gaps, then you need to download the necessary market data (for example, from **Финам**).
+To do this, on the **Common** tab select **Securities** so that the **All securities** tab appears. Before gluing the data, check which market data is available. Select the path where the data is located and sequentially view the instruments that you plan to glue. If there are gaps, download the missing market data (for example, from **Финам**).
 
 ![HydraGluingCheckData](../../../images/hydragluingcheckdata.png)
 
-As an example, we will consider gluing on an RTS index futures.
+As an example, consider combining RTS index futures.
 
-1. To create a continuous futures, click the **Create security \=\> Continuous security** button on the **All securities** tab.![Hydra Gluing Check Data 00](../../../images/hydragluingcheckdata_00.png)
+1. To create a continuous futures contract, click the **Create security \=\> Continuous security** button on the **All securities** tab.![Hydra Gluing Check Data 00](../../../images/hydragluingcheckdata_00.png)
 
    After that, the following window will appear:![HydraGluingWindow](../../../images/hydragluingwindow.png)
 2. To create a continuous futures, you need to specify a name and add contracts.
@@ -16,10 +16,10 @@ As an example, we will consider gluing on an RTS index futures.
    There are two ways to add contracts.
    - Manually by clicking the ![hydra add](../../../images/hydra_add.png) button.![HydraGluingCSCustom](../../../images/hydragluingcscustom.png)
    - If you set the first two letters of the contract as a name, for example, RI, and click the **Auto** button, then all the instruments found in the database will be added.![HydraGluingCSAuto](../../../images/hydragluingcsauto.png)
-3. We select the necessary contracts and set the transition dates. ![Hydra GluingCSAuto 00](../../../images/hydragluingcsauto_00.png)
-4. Next, assign the instrument identifier **RI\_long9@FORTS** and click the **OK** button, after which a new instrument will be created
-5. Next, you need to click the [Candles](../working_with_data/view_and_export/candles.md) button on the **Common** tab, select the resulting instrument, data period, set the **Composite element** value in the **Build from** field. Then click the ![hydra find](../../../images/hydra_find.png) button. ![HydraGluingTrades](../../../images/hydragluingtrades.png)
+3. Select the required contracts and set their transition dates. ![Hydra GluingCSAuto 00](../../../images/hydragluingcsauto_00.png)
+4. Next, assign the instrument identifier **RI\_long9@FORTS** and click the **OK** button, after which a new instrument will be created.
+5. Next, click the [Candles](../working_with_data/view_and_export/candles.md) button on the **Common** tab, select the resulting instrument and data period, set the **Composite element** value in the **Build from** field, and then click the ![hydra find](../../../images/hydra_find.png) button. ![HydraGluingTrades](../../../images/hydragluingtrades.png)
 
-The generated data can be exported to Excel, xml, Json or txt formats. The export is performed using the drop\-down list
+The generated data can be exported to Excel, XML, JSON or TXT formats. Export is performed using the drop-down list.
 
 ![hydra export](../../../images/hydra_export.png)

--- a/en/topics/hydra/instruments_and_boards/editing_instruments.md
+++ b/en/topics/hydra/instruments_and_boards/editing_instruments.md
@@ -1,21 +1,21 @@
 # Editing instruments
 
-To edit an instrument (for example, when the instrument was not filled with all the necessary data), double click the instrument or click the ![hydra edit](../../../images/hydra_edit.png) button to open the window in which to perform the necessary settings: 
+To edit an instrument (for example, if it was created without all required data), double-click the instrument or click the ![hydra edit](../../../images/hydra_edit.png) button to open the window where you can make the necessary changes:
 
 Go to the **Securities** window.
 
 ![hydra security edit 00](../../../images/hydra_security_edit_00.png)
 
-Then a window for editing will open.
+The editing window will open.
 
 ![hydra security edit](../../../images/hydra_security_edit.png)
 
-If necessary, you can edit the instrument group. To do this, select an instrument group and click on the ![hydra edit](../../../images/hydra_edit.png) button. 
+If necessary, you can edit the instrument group. Select an instrument group and click the ![hydra edit](../../../images/hydra_edit.png) button.
 
 ![hydra securities edit 00](../../../images/hydra_securities_edit_00.png)
 
-Then you can edit the group.
+Then edit the group as needed.
 
 ![hydra securities edit](../../../images/hydra_securities_edit.png)
 
-If the selected instrument group has the same values, this field will be filled with this value. If the values are different, then this field will be empty. For example, two instruments are selected with the Price Step value equal to 1, one instrument has a lot size of 10, the other \- 100. Accordingly, the Price Step field will be 1, and the Volume Step field will be empty. 
+If all selected instruments have the same value in a field, that value will be displayed. If the values differ, the field will be empty. For example, if two instruments have a Price Step of 1 but one has a lot size of 10 and the other 100, the Price Step field will show 1, and the Volume Step field will be empty.

--- a/en/topics/hydra/instruments_and_boards/extended_instrument_info.md
+++ b/en/topics/hydra/instruments_and_boards/extended_instrument_info.md
@@ -1,17 +1,17 @@
 # Extended instrument info
 
-Sources of extended information on instruments are **CSV** files located in the "c:\\Users\\Users\\Documents\\StockSharp\\Hydra\\Extended info\\" folder, which are automatically loaded when [Hydra](../../hydra.md) starts.
+Sources of extended information are **CSV** files located in the `c:\\Users\\Users\\Documents\\StockSharp\\Hydra\\Extended info\\` folder. They are automatically loaded when [Hydra](../../hydra.md) starts.
 
-Extended information can be any necessary information on an instrument (for example, country, city, board, etc.). 
+Extended information can include any additional details about an instrument (for example, country, city, board, etc.).
 
-Each source of extended information (CSV file) contains a list of instruments and properties of extended information available in the source for each of the instruments. For each source of extended information, the extended information will be unique.
+Each source of extended information (CSV file) contains a list of instruments and the available properties. For each source, the extended information is unique.
 
-If the source does not contain extended information on an instrument, then empty cells will be displayed in the columns of the list of all instruments corresponding to the extended information
+If the source does not contain extended information for an instrument, the corresponding columns in the instruments list will be empty.
 
 To select the required extended information, you need:
 
-1. in the Securities tab, click on the **Extended information** button![hydra Extension Info securities](../../../images/hydra_extensioninfo_securities.png)
-2. Then a window will appear in which you need to select the path to the required CSV file![hydra Extension Info window](../../../images/hydra_extensioninfo_window.png)
+1. In the **Securities** tab, click the **Extended information** button![hydra Extension Info securities](../../../images/hydra_extensioninfo_securities.png)
+2. A window will appear in which you need to select the path to the required CSV file![hydra Extension Info window](../../../images/hydra_extensioninfo_window.png)
 
 Below is an example of a **CSV** file of extended information opened in different editors: **MS Excel** and **Notepad**.
 

--- a/en/topics/hydra/instruments_and_boards/index.md
+++ b/en/topics/hydra/instruments_and_boards/index.md
@@ -2,15 +2,15 @@
 
 With [Hydra](../../hydra.md), you can create your own index.
 
-To do this, on the **Common** tab, you need to select **Securities**, the **All Securities** tab will appear.
+On the **Common** tab select **Securities** so that the **All Securities** tab appears.
 
-Before creating the **Index**, you need to check which market data is available. To do this, select the path where the data stored and in turn view the instruments that are supposed to participate in the calculation of the index. If there are omissions, then you need to download the necessary market data (for example, from Finam).
+Before creating the **Index**, check which market data is available. Select the path where the data is stored and sequentially view the instruments that should participate in the calculation of the index. If there are gaps, download the necessary market data (for example, from Finam).
 
 ![HydraGluingCheckData](../../../images/hydragluingcheckdata.png)
 
-As an example, the instrument ratio index AAPL@NYSE\/GOOG@NYSE will be considered.
+As an example, we will consider the instrument ratio index AAPL@NYSE\/GOOG@NYSE.
 
-The first step is the creation of the **Index**. To do this, click on the **All Securities** tab, the **Create security\=\>Index** button, after that, the following window will appear:
+The first step is to create the **Index**. Click the **Create security\=\>Index** button on the **All Securities** tab, after which the following window will appear:
 
 ![hydra index sec](../../../images/hydra_index_sec.png)
 
@@ -35,10 +35,10 @@ To create the **Index** instrument, you must specify a name and add the mathemat
 - **tan(a)** \- Returns the tangent of the specified angle.
 - **truncate(a)** \- Calculates the integer part of the specified number.
 
-Next, you need to click the [Candles](../working_with_data/view_and_export/candles.md) button on the **Common** tab, select the obtained **Index** instrument, the data period, in the **Create From:** field set the **Composite Element** value. Then press the button ![hydra find](../../../images/hydra_find.png).
+Next, click the [Candles](../working_with_data/view_and_export/candles.md) button on the **Common** tab, select the created **Index** instrument and the data period, set **Composite Element** in the **Create From:** field, and then press the ![hydra find](../../../images/hydra_find.png) button.
 
 ![hydra index candle](../../../images/hydra_index_candle.png)
 
-The generated data can be exported to Excel, xml or txt formats. Export is done using the drop\-down list:
+The generated data can be exported to Excel, XML or TXT formats. Export is done using the drop-down list.
 
 ![hydra export](../../../images/hydra_export.png)

--- a/en/topics/hydra/instruments_and_boards/instruments_list.md
+++ b/en/topics/hydra/instruments_and_boards/instruments_list.md
@@ -4,7 +4,7 @@ If you click the **Instruments** button on the General tab, the **Instruments** 
 
 ![hydra securitiesPanel 00](../../../images/hydra_securitiespanel_00.png)
 
-At the bottom of the **Instruments** panel are buttons that allow to:
+At the bottom of the **Instruments** panel are buttons that allow you to:
 
 - Add a new instrument, as described in the clause [Create instrument](create_instrument.md).
 - Add a new index, as described in the clause [Index](index.md).

--- a/en/topics/hydra/instruments_and_boards/matching_instruments_connections.md
+++ b/en/topics/hydra/instruments_and_boards/matching_instruments_connections.md
@@ -8,9 +8,9 @@ This is also useful when trading the same instrument on different trading boards
 
 To match instruments and connections you need:
 
-1. Go to the **Securities** tab and click the **Securities and connections button**.![Designer Security mapping 01 00](../../../images/designer_security_mapping_01_00.png)
+1. Go to the **Securities** tab and click the **Securities and Connections** button.![Designer Security mapping 01 00](../../../images/designer_security_mapping_01_00.png)
 2. In the list of connections, select the required connection.![Designer Security mapping 01](../../../images/designer_security_mapping_01.png)
-3. We fill in all the columns.
+3. Fill in all the columns.
 
    For example:
 
@@ -22,4 +22,4 @@ To match instruments and connections you need:
    | **Transaq**                                                                       | **CQG Continuum**                                                                 |
    | --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
    | ![Designer Security mapping 01 02](../../../images/designer_security_mapping_01_02.png) | ![Designer Security mapping 01 03](../../../images/designer_security_mapping_01_03.png) |
-4. Now all downloaded data, in our case for APPLE shares, will be saved in one place 
+4. Now all downloaded data, in our case for APPLE shares, will be saved in one place.

--- a/en/topics/hydra/server_mode/emulation_setup.md
+++ b/en/topics/hydra/server_mode/emulation_setup.md
@@ -22,7 +22,7 @@ This mode is used when [testing strategies](../../shell/user_interface/emulation
 - **Percentage of errors** \- the percentage of errors in registering new orders (from 0 to 100).
 - **Latency** \- the minimum latency of registered orders.
 - **Re\-registration** \- whether re\-registration of orders will be supported as a single transaction.
-- **Buffering period** \- a parameter that is responsible for the period of sending whole packets in order to emulate network latency and buffering the work of the exchange core
+- **Buffering period** \- a parameter that is responsible for the period of sending whole packets in order to emulate network latency and buffer the work of the exchange core.
 - **Order ID** \- the number with which the emulator will generate identifiers for orders.
 - **Trade identifier** \- the number with which the emulator will generate identifiers for trades.
 - **Transaction** \- the number with which the emulator will generate identifiers for order transactions.

--- a/en/topics/hydra/server_mode/settings.md
+++ b/en/topics/hydra/server_mode/settings.md
@@ -1,6 +1,6 @@
 # Settings
 
-[Hydra](../../hydra.md) can be used in server mode, in this mode you can remotely connect to [Hydra](../../hydra.md) and get the existing data in the storage. You can connect to [Hydra](../../hydra.md) running in server mode from [Designer](../../designer.md) (see [Getting started](../../designer/market_data_storage/getting_started.md) in the [Designer](../../designer.md) documentation for how to do this). You can also connect to [Hydra](../../hydra.md) via [API](../../api.md) (how to do this is described in the [FIX\/FAST connectivity](fix_fast_connectivity.md) items).
+[Hydra](../../hydra.md) can be used in server mode, in this mode you can remotely connect to [Hydra](../../hydra.md) and get the existing data in the storage. You can connect to [Hydra](../../hydra.md) running in server mode from [Designer](../../designer.md) (see [Getting started](../../designer/market_data_storage/getting_started.md) in the [Designer](../../designer.md) documentation for how to do this). You can also connect to [Hydra](../../hydra.md) via the [API](../../api.md) (see the [FIX/FAST connectivity](fix_fast_connectivity.md) section for details).
 
 In server mode, the [Hydra](../../hydra.md) program allows the user to work using one connection, with several programs at once. By setting the access key in the program settings, the user can simultaneously work with one source under one account.
 
@@ -18,13 +18,13 @@ After that, click on the **Settings** button to open the server mode settings wi
 
 - **FIX server** \- switch [Hydra](../../hydra.md) to server mode, distributing live trading and historical data via the FIX protocol. 
 
-  In this settings section, the user configures the connection for working with sources: 
+  In this section, you configure the connection for working with sources: 
   1. **ConvertToLatin** \- convert Cyrillic to Latin 
   2. **QuotesInterval** \- quotes update period 
   3. **TransactionSession** \- setting of a trading session. Setting up for trading via the [Hydra](../../hydra.md) program. 
 
-     The setting allows to set up: Dialect of the FIX protocol, Sender and Recipient, Data format and other settings. See [FIXServer properties](https://doc.stocksharp.ru/html/Properties_T_StockSharp_Fix_FixServer.htm) for details.
-  4. **MarketDataSession** \- settings for transfer of market data received using [Hydra](../../hydra.md). See Подробнее см. [FIXServer properties](https://doc.stocksharp.ru/html/Properties_T_StockSharp_Fix_FixServer.htm) for details. 
+     This setting allows you to configure Dialect of the FIX protocol, Sender and Recipient, Data format and other settings. See [FIXServer properties](https://doc.stocksharp.ru/html/Properties_T_StockSharp_Fix_FixServer.htm) for details.
+  4. **MarketDataSession** \- settings for transfer of market data received using [Hydra](../../hydra.md). See [FIXServer properties](https://doc.stocksharp.ru/html/Properties_T_StockSharp_Fix_FixServer.htm) for details. 
   5. **KeepSubscriptionsOnDisconnect** \- keeping subscriptions when disconnected from the source. 
   6. **DeadSessionCleanupInterval** \- after what time interval the information will be cleared if the connection is disconnected.
 - **Authorization** \- authorization to gain access to the Hydra server 

--- a/en/topics/hydra/working_with_data/any_market_data_types.md
+++ b/en/topics/hydra/working_with_data/any_market_data_types.md
@@ -1,6 +1,6 @@
 # Any market data types
 
-[Hydra](../../hydra.md) allows you to use another type of data to get a number of market data.
+[Hydra](../../hydra.md) allows you to use alternative data types to obtain various kinds of market data.
 
 This is necessary if the source does not allow downloading the required market data. So, for example, several types of market data can be used at once to build the **Order book**.
 
@@ -8,16 +8,16 @@ IMPORTANT\! **Order book** can be built from the **Order Log** or **Level 1**, p
 
 It is worth remembering that **Level 1** values can be downloaded from any source that provides real\-time market data. **Level 1** can also be received by [converting](../tasks/converter.md) from the **Order book**. 
 
-To build you need:
+To build it, you need to:
 
 1. Select the period and instrument for which you want to get market data.![hydra LEVEL 1 build depth data](../../../images/hydra_level1_build_depth_data.png)
 2. Select the **Build from** field and select the required data type![hydra type build data](../../../images/hydra_type_build_data.png)
 
    IMPORTANT\! If **Order Book, Order Log, Level 1** are selected as a source for building a candle, a selection of additional parameters appears.![hydra ext proper build data](../../../images/hydra_ext_proper_build_data.png)
-3. After setting, you need to click on the ![hydra candles](../../../images/hydra_candles.png) button.![hydra LEVEL 1 build depth data result](../../../images/hydra_level1_build_depth_data_result.png)
+3. After setting the parameters, click the ![hydra candles](../../../images/hydra_candles.png) button.![hydra LEVEL 1 build depth data result](../../../images/hydra_level1_build_depth_data_result.png)
 
 To build **Candles**, the option of building candles of a larger Time Frame from candles of a smaller Time Frame is also available. 
 
-So, for example, if there are candles with a Time Frame of 1 minute, you can build candles with a Time Frame of 5 minutes from them by selecting the appropriate type in the **Build from** line. 
+For example, if there are candles with a Time Frame of 1 minute, you can build candles with a Time Frame of 5 minutes from them by selecting the appropriate type in the **Build from** line.
 
 **Watch [video tutorial](../videos/building_order_books.md)**

--- a/en/topics/hydra/working_with_data/view_and_export/option_desk.md
+++ b/en/topics/hydra/working_with_data/view_and_export/option_desk.md
@@ -1,6 +1,6 @@
 # Option desk
 
-In the window that appears, select the desired time range, the underlying asset, add options for the underlying asset, and click the button ![hydra find](../../../../images/hydra_find.png):
+In the window that appears, select the desired time range, choose the underlying asset, add options for it, and click the ![hydra find](../../../../images/hydra_find.png) button:
 
 If there is no history, but there is data on the spread, you can calculate the main Greeks (Delta, Gamma, Vega, Theta, Ro, Volatility (implicit)), to do this you need to select them in the **Calculate Greeks** field. 
 


### PR DESCRIPTION
## Summary
- clean up phrasing in Hydra boards description
- improve explanations for continuous futures
- clarify instrument editing workflow
- refine extended instrument info steps
- polish index creation docs and other references

## Testing
- `make --version`

------
https://chatgpt.com/codex/tasks/task_e_68435028ae4c8323a0c248a524685a0e