### PR TITLE
Fix grammar errors in event model docs

### DIFF
--- a/en/topics/api/strategies/event_model/rules_suspension.md
+++ b/en/topics/api/strategies/event_model/rules_suspension.md
@@ -1,8 +1,8 @@
 # Rules suspension
 
-Sometimes you want to set multiple rules in suspension mode (prevent to trigger any of them until code initialization will be finished). To do this, the [MarketRuleHelper.SuspendRules](xref:StockSharp.Algo.MarketRuleHelper.SuspendRules(System.Action))**(**[System.Action](xref:System.Action) action **)** method is used. 
+Sometimes you want to set multiple rules in suspension mode (prevent them from triggering until code initialization will be finished). To do this, the [MarketRuleHelper.SuspendRules](xref:StockSharp.Algo.MarketRuleHelper.SuspendRules(System.Action))**(**[System.Action](xref:System.Action) action **)** method is used. 
 
-## Rules suspension using
+## Using rule suspension
 
 - Out of the strategy:
 

--- a/ru/topics/api/strategies/event_model/rules_mutually_exclusive.md
+++ b/ru/topics/api/strategies/event_model/rules_mutually_exclusive.md
@@ -1,8 +1,8 @@
 # Взаимоисключающие правила
 
-Взаимоисключающие правила, это правила которые удаляются по активации одного из этих правил. Для этого вызвается метод [MarketRuleHelper.Exclusive](xref:StockSharp.Algo.MarketRuleHelper.Exclusive(StockSharp.Algo.IMarketRule,StockSharp.Algo.IMarketRule))**(**[StockSharp.Algo.IMarketRule](xref:StockSharp.Algo.IMarketRule) rule1, [StockSharp.Algo.IMarketRule](xref:StockSharp.Algo.IMarketRule) rule2 **)** в который передается правило, которое будет удалено при активации данного правила.
+Взаимоисключающие правила, это правила которые удаляются по активации одного из этих правил. Для этого вызывается метод [MarketRuleHelper.Exclusive](xref:StockSharp.Algo.MarketRuleHelper.Exclusive(StockSharp.Algo.IMarketRule,StockSharp.Algo.IMarketRule))**(**[StockSharp.Algo.IMarketRule](xref:StockSharp.Algo.IMarketRule) rule1, [StockSharp.Algo.IMarketRule](xref:StockSharp.Algo.IMarketRule) rule2 **)** в который передается правило, которое будет удалено при активации данного правила.
 
-Например, регистрируется два правила, на успешную и неуспешную регистрацию заявки, одно из них нужно удалить в случае активации другого:
+Например, регистрируются два правила, на успешную и неуспешную регистрацию заявки, одно из них нужно удалить в случае активации другого:
 
 ```cs
 var order = this.CreateOrder(direction, (decimal) Security.GetCurrentPrice(direction), Volume);
@@ -18,7 +18,7 @@ ruleRegFailed
 	.Once()
 	.Apply(this)
 	.Exclusive(ruleReg);
-// регистрирация заявки
+// регистрация заявки
 RegisterOrder(order);
 		
 ```
@@ -39,7 +39,7 @@ ruleRegFailed
 	.Do(() => this.AddInfoLog("Заявка не принята биржей"))
 	.Once()
 	.Apply(this);
-// регистрирация заявки
+// регистрация заявки
 RegisterOrder(order);
 		
 ```

--- a/ru/topics/api/strategies/event_model/rules_using.md
+++ b/ru/topics/api/strategies/event_model/rules_using.md
@@ -97,7 +97,7 @@
       .Do(() => this.AddInfoLog("Заявка полностью исполнена"))
       .Once()
       .Apply(this);
-  // регистрирация заявки
+  // регистрация заявки
   RegisterOrder(order);
   ```
   


### PR DESCRIPTION
## Summary
- correct Russian grammar in mutually exclusive rules
- fix typo in Russian rules_using
- rephrase English rule suspension docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860fe67382083238b5e59d60715a1ef