### PR TITLE
Fix grammatical errors in data source docs

### DIFF
--- a/en/topics/designer/strategies/using_visual_designer/elements/data_sources/index.md
+++ b/en/topics/designer/strategies/using_visual_designer/elements/data_sources/index.md
@@ -8,7 +8,7 @@ The cube is used to create your own index.
 
 Outgoing sockets
 
-- **Security** \- the calculated index, represented as an **Security**.
+- **Security** \- the calculated index, represented as a **Security**.
 
 ### Parameters
 

--- a/en/topics/designer/strategies/using_visual_designer/elements/data_sources/ticks.md
+++ b/en/topics/designer/strategies/using_visual_designer/elements/data_sources/ticks.md
@@ -8,19 +8,19 @@ This block is used to receive **Tick** data for an instrument.
 
 Incoming Sockets
 
-- **Instrument** � the instrument for which **Level1** data needs to be received.
+- **Instrument** – the instrument for which **Level1** data needs to be received.
 
 ### Outgoing Sockets
 
 Outgoing Sockets
 
-- **Tick** � a tick transaction.
+- **Tick** – a tick transaction.
 
 ### Parameters
 
 Parameters
 
-- **Subscribe on Signal** � subscribe to data only after a trigger arrives.
+- **Subscribe on Signal** – subscribe to data only after a trigger arrives.
 
 ## See Also
 

--- a/en/topics/designer/strategies/using_visual_designer/elements/data_sources/variable.md
+++ b/en/topics/designer/strategies/using_visual_designer/elements/data_sources/variable.md
@@ -2,7 +2,7 @@
 
 ![Designer Variable 00](../../../../../../images/designer_variable_00.png)
 
-The cube is used to store values, pass the previously stored value further along the chain of elements.
+The cube is used to store values and pass the previously stored value further along the chain of elements.
 
 ### Incoming sockets
 


### PR DESCRIPTION
## Summary
- fix article usage in Index block docs
- tweak wording in Variable block docs
- correct dashes in Ticks block docs

## Testing
- `codespell -q 3 en/topics/designer/strategies/using_visual_designer/elements/data_sources | head`
- `codespell -q 3 ru/topics/designer/strategies/using_visual_designer/elements/data_sources | head`

------
https://chatgpt.com/codex/tasks/task_e_6860fe12e8d88323ac0ac44c08335789