### PR TITLE
Fix grammar mistakes in instruments docs

### DIFF
--- a/en/topics/api/graphical_user_interface/instruments/continuous_futures.md
+++ b/en/topics/api/graphical_user_interface/instruments/continuous_futures.md
@@ -6,8 +6,8 @@
 
 This component includes: 
 
-- Special [SecurityIdTextBox](xref:StockSharp.Xaml.SecurityIdTextBox) text field, whivh generates a *continuous* instrument with the input of Id \- \[Code\]@\[Board\]. 
-- The [SecurityJumpsEditor](xref:StockSharp.Xaml.SecurityJumpsEditor) component is a special DataGrid for working with instruments that are part of a *continuous* instrument. The component instruments are wrapped in the [SecurityJump](xref:StockSharp.Xaml.SecurityJump), class, which has two properties: [SecurityJump.Security](xref:StockSharp.Xaml.SecurityJump.Security) and [SecurityJump.Date](xref:StockSharp.Xaml.SecurityJump.Date) (roll forward). The added instruments are stored in the [SecurityJumpsEditor.Jumps](xref:StockSharp.Xaml.SecurityJumpsEditor.Jumps). list. The component has the [SecurityJumpsEditor.Validate](xref:StockSharp.Xaml.SecurityJumpsEditor.Validate) function to check the correctness of the component instruments. 
+- Special [SecurityIdTextBox](xref:StockSharp.Xaml.SecurityIdTextBox) text field, which generates a *continuous* instrument with the input of Id \- \[Code\]@\[Board\]. 
+- The [SecurityJumpsEditor](xref:StockSharp.Xaml.SecurityJumpsEditor) component is a special DataGrid for working with instruments that are part of a *continuous* instrument. The instruments are wrapped in the [SecurityJump](xref:StockSharp.Xaml.SecurityJump), class, which has two properties: [SecurityJump.Security](xref:StockSharp.Xaml.SecurityJump.Security) and [SecurityJump.Date](xref:StockSharp.Xaml.SecurityJump.Date) (roll forward). The added instruments are stored in the [SecurityJumpsEditor.Jumps](xref:StockSharp.Xaml.SecurityJumpsEditor.Jumps) list. The component has the [SecurityJumpsEditor.Validate](xref:StockSharp.Xaml.SecurityJumpsEditor.Validate) function to check the correctness of the component instruments. 
 - Buttons for adding\/removing instruments. 
 - **Auto** button allows you to automatically create a *continuous* instrument. 
 - **Ok** button completes the creation of a *continuous* instrument. 

--- a/en/topics/api/graphical_user_interface/instruments/index.md
+++ b/en/topics/api/graphical_user_interface/instruments/index.md
@@ -19,7 +19,7 @@ ConfigManager.RegisterService<ICompilerService>(new RoslynCompilerService());
 ...
 ```
 
-Next, the securities necessary for index calculating should be passed to [IndexEditor](xref:StockSharp.Xaml.IndexEditor):
+Next, the securities necessary for index calculation should be passed to [IndexEditor](xref:StockSharp.Xaml.IndexEditor):
 
 ```cs
 ...

--- a/en/topics/api/graphical_user_interface/instruments/window.md
+++ b/en/topics/api/graphical_user_interface/instruments/window.md
@@ -1,6 +1,6 @@
 # Window
 
-The [SecurityCreateWindow](xref:StockSharp.Xaml.SecurityCreateWindow) component is a window for creating and editing an instrument. The component consists of two main elements: the special text field [SecurityIdTextBox](xref:StockSharp.Xaml.SecurityIdTextBox) the property editing grid [PropertyGridEx](xref:StockSharp.Xaml.PropertyGrid.PropertyGridEx). You can access the created (edited) instrument with the [SecurityCreateWindow.Security](xref:StockSharp.Xaml.SecurityCreateWindow.Security) property. 
+The [SecurityCreateWindow](xref:StockSharp.Xaml.SecurityCreateWindow) component is a window for creating and editing an instrument. The component consists of two main elements: the special text field [SecurityIdTextBox](xref:StockSharp.Xaml.SecurityIdTextBox) and the property editing grid [PropertyGridEx](xref:StockSharp.Xaml.PropertyGrid.PropertyGridEx). You can access the created (edited) instrument with the [SecurityCreateWindow.Security](xref:StockSharp.Xaml.SecurityCreateWindow.Security) property. 
 
 Below is the appearance of the component and the code snippet with its use. 
 

--- a/ru/topics/api/graphical_user_interface/instruments/index.md
+++ b/ru/topics/api/graphical_user_interface/instruments/index.md
@@ -19,7 +19,7 @@ ConfigManager.RegisterService<ICompilerService>(new RoslynCompilerService());
 ...
 ```
 
-Далее в [IndexEditor](xref:StockSharp.Xaml.IndexEditor) следует передать инструменты необходимые для расчета индекса:
+Далее в [IndexEditor](xref:StockSharp.Xaml.IndexEditor) следует передать инструменты, необходимые для расчета индекса:
 
 ```cs
 ...


### PR DESCRIPTION
## Summary
- fix Russian typo in IndexEditor instructions
- fix English grammar in index and window docs
- clean up text for continuous futures

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860f00a96dc8323bee4d289836f5f2c