### PR TITLE
Fix minor grammar errors in Converter doc

### DIFF
--- a/en/topics/designer/strategies/using_visual_designer/elements/converters/converter.md
+++ b/en/topics/designer/strategies/using_visual_designer/elements/converters/converter.md
@@ -2,13 +2,13 @@
 
 ![Designer Converter 00](../../../../../../images/designer_converter_00.png)
 
-The cube is used to convert complex objects into simple data types. For example, it allows to get the value of the price step for the instrument. 
+The cube is used to convert complex objects into simple data types. For example, it allows you to get the value of the price step for the instrument.
 
 ### Incoming sockets
 
 Incoming sockets
 
-- **Any data** \- the certain type of complex objects that are received.
+- **Any data** \- a certain type of complex objects that are received.
 
 ### Outgoing sockets
 


### PR DESCRIPTION
## Summary
- fix wording in the English Converter article

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860fe0b6c708323ad30698f6f0b8a8d