### PR TITLE
Fix grammar errors in RSS docs

### DIFF
--- a/en/topics/api/connectors/common/rss/graphical_configuration_rss.md
+++ b/en/topics/api/connectors/common/rss/graphical_configuration_rss.md
@@ -5,8 +5,8 @@ For all [S\#](../../../../api.md) products, graphical configuration of the conne
 ![API GUI Settings RSS](../../../../../images/api_gui_settings_rss.png)
 
 - **Address** \- RSS feed address.
-- **Dates format** \- Dates format Required to be filled if RSS stream format is different from ddd, dd MMM yyyy HH:mm:ss zzzz.
-- **Heart beat** \- Server check interval for track the connection alive. By default equal to 1 minute.
+- **Dates format** \- Dates format. Required if the RSS stream format is different from `ddd, dd MMM yyyy HH:mm:ss zzzz`.
+- **Heart beat** \- Server check interval to track that the connection is alive. By default equal to 1 minute.
 - **Reconnection settings** \- Mechanism for tracking connections with the trading system settings. ([Reconnection settings](../../reconnection_settings.md))
 
 ## Recommended content

--- a/ru/topics/api/connectors/common/rss/adapter_initialization_rss.md
+++ b/ru/topics/api/connectors/common/rss/adapter_initialization_rss.md
@@ -1,6 +1,6 @@
 # Инициализация адаптера RSS
 
-Код ниже демонстрирует как инициализировать [RssMessageAdapter](xref:StockSharp.Rss.RssMessageAdapter) и передать его в [Connector](xref:StockSharp.Algo.Connector).
+Код ниже демонстрирует, как инициализировать [RssMessageAdapter](xref:StockSharp.Rss.RssMessageAdapter) и передать его в [Connector](xref:StockSharp.Algo.Connector).
 
 ```cs
 var messageAdapter = new RssMessageAdapter(Connector.TransactionIdGenerator)


### PR DESCRIPTION
## Summary
- fix grammar in English RSS config docs
- add missing comma in Russian RSS adapter initialization docs

## Testing
- `python3 -m py_compile increase_links.py tabify_code_blocks.py`

------
https://chatgpt.com/codex/tasks/task_e_6860f0940d6c8323b373ff135d4aaf48