### PR TITLE
Fix image alt text

### DIFF
--- a/en/topics/api/graphical_user_interface/market_data/level1.md
+++ b/en/topics/api/graphical_user_interface/market_data/level1.md
@@ -1,6 +1,6 @@
 # Level1
 
-![GUI Leve1Grid](../../../../images/gui_leve1grid.png)
+![GUI Level1Grid](../../../../images/gui_leve1grid.png)
 
 [Level1Grid](xref:StockSharp.Xaml.Level1Grid) - a table for displaying Level1 fields. This table uses data in the form of [Level1ChangeMessage](xref:StockSharp.Messages.Level1ChangeMessage) messages.
 

--- a/ru/topics/api/graphical_user_interface/market_data/level1.md
+++ b/ru/topics/api/graphical_user_interface/market_data/level1.md
@@ -1,6 +1,6 @@
 # Level1
 
-![GUI Leve1Grid](../../../../images/gui_leve1grid.png)
+![GUI Level1Grid](../../../../images/gui_leve1grid.png)
 
 [Level1Grid](xref:StockSharp.Xaml.Level1Grid) - таблица для отображения полей Level1. Эта таблица использует данные в виде сообщений [Level1ChangeMessage](xref:StockSharp.Messages.Level1ChangeMessage). 
 


### PR DESCRIPTION
## Summary
- fix typo in `level1.md` alt text for Russian and English docs

## Testing
- `grep -R "Leve1Grid" -n | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_6860f018ef908323a4185639bc59de67