### PR TITLE
Fix grammar in Hydra videos docs

### DIFF
--- a/en/topics/hydra/videos/instruments_downloading.md
+++ b/en/topics/hydra/videos/instruments_downloading.md
@@ -1,3 +1,3 @@
-# Instruments downloading
+# Downloading instruments
 
 > [!Video https://www.youtube.com/embed/nXEvtiHQH5c]

--- a/en/topics/hydra/videos/sources_samples.md
+++ b/en/topics/hydra/videos/sources_samples.md
@@ -1,4 +1,4 @@
-# Sources samples
+# Source samples
 
 Connection settings in [Designer](../../designer.md), [Terminal](../../terminal.md), [Hydra](../../hydra.md). 
 

--- a/ru/topics/hydra/videos/sources_samples.md
+++ b/ru/topics/hydra/videos/sources_samples.md
@@ -2,7 +2,7 @@
 
 Настройки подключений в программах [Designer](../../designer.md), [Terminal](../../terminal.md), [Hydra](../../hydra.md). 
 
-Подробно настройки подключений по средством различных коннекторов можно узнать [здесь](../../api/connectors/graphical_configuration.md)
+Подробно настройки подключений посредством различных коннекторов можно узнать [здесь](../../api/connectors/graphical_configuration.md)
 
 - [Подключение к Финам](sources_samples/finam.md)
 - [Подключение к Oanda](sources_samples/oanda.md)


### PR DESCRIPTION
## Summary
- fix a Russian typo in sources_samples.md
- adjust titles in English docs for hydra videos

## Testing
- `python -m py_compile increase_links.py tabify_code_blocks.py`

------
https://chatgpt.com/codex/tasks/task_e_6860ef95078c8323bf82120a86dad569