### PR TITLE
Fix grammar in shell connector docs

### DIFF
--- a/en/topics/shell/connections_settings/connector_settings.md
+++ b/en/topics/shell/connections_settings/connector_settings.md
@@ -1,3 +1,3 @@
 # Connector settings
 
-See [Connectors settings](../../designer/connections_settings/connectors_settings.md).
+See [Connector settings](../../designer/connections_settings/connectors_settings.md).

--- a/ru/topics/shell/connections_settings.md
+++ b/ru/topics/shell/connections_settings.md
@@ -1,5 +1,3 @@
 # Настройки подключения
 
-См. 
-
-[Настройки подключения](../designer/connections_settings.md)
+См. [Настройки подключения](../designer/connections_settings.md)

--- a/ru/topics/shell/connections_settings/connector_settings.md
+++ b/ru/topics/shell/connections_settings/connector_settings.md
@@ -1,5 +1,3 @@
 # Настройки коннекторов
 
-См. 
-
-[Настройки коннекторов](../../designer/connections_settings/connectors_settings.md)
+См. [Настройки коннекторов](../../designer/connections_settings/connectors_settings.md).


### PR DESCRIPTION
## Summary
- update connector settings link text in English
- fix the phrasing of the Russian connection settings pages

## Testing
- `python --version`

------
https://chatgpt.com/codex/tasks/task_e_6860efab9b0483239db1938d2429b15a