### PR TITLE
Fix grammar in terminal notifications docs

### DIFF
--- a/en/topics/terminal/notifications.md
+++ b/en/topics/terminal/notifications.md
@@ -4,7 +4,7 @@ Notifications are a system for alerting a user about a pre\-specified event that
 
 Notifications can be specified for a wide range of trading events for the following objects: portfolio, position, Level 1, news. For example, exceeding the weighted average position price of a certain value or the appearance of news with a specific title.
 
-Notifications can be of the following form:
+Notifications can be of the following forms:
 
 - **Window** \- a small pop\-up window with a message will appear in the corner of the screen.
 - **Music** \- the music will be played.

--- a/ru/topics/terminal/notifications.md
+++ b/ru/topics/terminal/notifications.md
@@ -16,4 +16,4 @@
 
 Для задания уведомления необходимо на панели уведомлений ([Панель уведомлений](notifications/notification_panel.md)) нажать на кнопку ![Designer Creation tool 00](../../images/designer_creation_tool_00.png) или нажать на кнопку ![Designer Alert Bell](../../images/designer_alert_bell.png) непосредственно на панелях, поддерживающих уведомления.
 
-О том как настраивать уведомления описано в пункте [Настройки уведомлений](notifications/notifications_setup.md).
+О том, как настраивать уведомления, описано в пункте [Настройки уведомлений](notifications/notifications_setup.md).


### PR DESCRIPTION
## Summary
- fix plural form in EN notifications docs
- fix commas in RU notifications docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860ee841fac832383046605f548a608