### PR TITLE
Fix typos in GUI documentation

### DIFF
--- a/en/topics/api/graphical_user_interface/commission_settings_window.md
+++ b/en/topics/api/graphical_user_interface/commission_settings_window.md
@@ -1,10 +1,10 @@
 # Commission settings window
 
-[CommissionWindow](xref:StockSharp.Xaml.CommissionWindow) \- \- A special window for setting the rules for charging a commission. 
+[CommissionWindow](xref:StockSharp.Xaml.CommissionWindow) - A special window for setting the rules for charging a commission.
 
 ![API ComissionWindow](../../../images/api_comissionwindow.png)
 
-Below is an example of the code to call window for setting the rules for charging a commission. 
+Below is an example of the code to call a window for setting the rules for charging a commission.
 
 ```cs
 		private void RiskButton_OnClick(object sender, RoutedEventArgs e)

--- a/en/topics/api/graphical_user_interface/notification_settings_window.md
+++ b/en/topics/api/graphical_user_interface/notification_settings_window.md
@@ -1,6 +1,6 @@
 # Notification settings window
 
-[AlertSettingsWindow](xref:StockSharp.Alerts.AlertSettingsWindow) \- window for configuring notifications of certain events 
+[AlertSettingsWindow](xref:StockSharp.Alerts.AlertSettingsWindow) - window for configuring notifications for certain events
 
 ![API GUI AlertWindow](../../../images/api_gui_alertwindow.png)
 

--- a/en/topics/api/graphical_user_interface/options.md
+++ b/en/topics/api/graphical_user_interface/options.md
@@ -3,7 +3,7 @@
 The [S\#](../../api.md) includes several graphic components to work with options. 
 
 - [OptionDesk](options/option_desk.md) \- the option desk.
-- [OptionPositionChart](options/position_chart.md) \- the chart showing the position and the options Greeks regarding to the underlying asset.
+- [OptionPositionChart](options/position_chart.md) \- the chart showing the position and the options Greeks regarding the underlying asset.
 
 ## Recommended content
 

--- a/ru/topics/api/graphical_user_interface/charts.md
+++ b/ru/topics/api/graphical_user_interface/charts.md
@@ -52,7 +52,7 @@
 
 ## IChartElement
 
-Все элементы, которые отображаются на графике должны, реализовывать интерфейс [IChartElement](xref:StockSharp.Charting.IChartElement). В [S\#](../../api.md) имеются следующие классы, реализующие этот интерфейс: 
+Все элементы, которые отображаются на графике, должны реализовывать интерфейс [IChartElement](xref:StockSharp.Charting.IChartElement). В [S\#](../../api.md) имеются следующие классы, реализующие этот интерфейс:
 
 - [ChartCandleElement](xref:StockSharp.Xaml.Charting.ChartCandleElement) \- элемент для отображения свечей.
 - [ChartIndicatorElement](xref:StockSharp.Xaml.Charting.ChartIndicatorElement) \- элемент для отображения индикаторов.


### PR DESCRIPTION
## Summary
- correct phrasing in the options page
- fix duplicate dash and article omission in commission window docs
- improve wording for alert settings
- remove an extra comma in the Russian charts documentation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860ee9a1e908323a22690f2aa6dc44b