### PR TITLE
Fix whitespace in market data docs

### DIFF
--- a/en/topics/api/market_data/getting_historical_data.md
+++ b/en/topics/api/market_data/getting_historical_data.md
@@ -33,7 +33,7 @@ To receive historical candles, you need to create a subscription and specify the
 ```cs
 // Create a subscription for 5-minute candles for the selected instrument
 var subscription = new Subscription(
-	DataType.TimeFrame(TimeSpan.FromMinutes(5)), 
+	DataType.TimeFrame(TimeSpan.FromMinutes(5)),
 	security)
 {
 	MarketData =
@@ -58,10 +58,10 @@ private void OnCandleReceived(Subscription subscription, ICandleMessage candle)
 	// Check that the candle belongs to our subscription
 	if (subscription != _subscription)
 		return;
-		
+
 	// Process the received candle
 	Console.WriteLine($"Candle received: {candle.OpenTime}, O:{candle.OpenPrice}, H:{candle.HighPrice}, L:{candle.LowPrice}, C:{candle.ClosePrice}, V:{candle.TotalVolume}");
-	
+
 	// For display on the chart, you can use:
 	// Chart.Draw(_candleElement, candle);
 }
@@ -87,7 +87,7 @@ private void OnCandleReceived(Subscription subscription, ICandleMessage candle)
 	// Check that the candle belongs to our subscription
 	if (subscription != _subscription)
 		return;
-		
+
 	// If you need to display only completed candles
 	if (candle.State == CandleStates.Finished)
 	{

--- a/en/topics/api/market_data/getting_news_data.md
+++ b/en/topics/api/market_data/getting_news_data.md
@@ -24,18 +24,18 @@ private void OnNewsReceived(Subscription subscription, News news)
 {
 	if (subscription != newsSubscription)
 		return;
-		
+
 	// Process the received news
 	Console.WriteLine($"News: {news.Id}");
 	Console.WriteLine($"Headline: {news.Headline}");
 	Console.WriteLine($"Source: {news.Source}");
 	Console.WriteLine($"Time: {news.ServerTime}");
 	Console.WriteLine($"URL: {news.Url}");
-	
+
 	// If there is news text
 	if (!string.IsNullOrEmpty(news.Story))
 		Console.WriteLine($"Story: {news.Story}");
-	
+
 	// If the news is related to specific instruments
 	if (news.SecurityId != null)
 		Console.WriteLine($"Instrument: {news.SecurityId}");
@@ -50,11 +50,11 @@ When subscribing to news, you can specify filtering parameters to receive only t
 // Create a subscription to news with filtering
 var filteredNewsSubscription = new Subscription(DataType.News)
 {
-	MarketData = 
+	MarketData =
 	{
 		// Specify the period for which to get news
 		From = DateTime.Now.Subtract(TimeSpan.FromHours(24)),
-		
+
 		// You can specify a specific news source
 		// For example, we use an RSS source
 		NewsSource = "CryptoNews"
@@ -73,7 +73,7 @@ StockSharp provides a special visual component [NewsPanel](xref:StockSharp.Xaml.
 var newsPanel = new NewsPanel();
 
 // Subscribe to the news received event and add news to the panel
-_connector.NewsReceived += (subscription, news) => 
+_connector.NewsReceived += (subscription, news) =>
 {
 	// To update UI elements
 	// you need to use the GuiAsync or GuiSync method
@@ -95,7 +95,7 @@ To get historical news for a specific period, you can use the same subscription 
 // Create a subscription to historical news
 var historicalNewsSubscription = new Subscription(DataType.News)
 {
-	MarketData = 
+	MarketData =
 	{
 		// Specify the period for which to get news
 		From = DateTime.Now.Subtract(TimeSpan.FromDays(7)),

--- a/en/topics/api/market_data/subscriptions.md
+++ b/en/topics/api/market_data/subscriptions.md
@@ -29,7 +29,7 @@ _connector.CandleReceived += (sub, candle) =>
 {
 	if (sub != subscription)
 		return;
-		
+
 	// Process the candle
 	Console.WriteLine($"Candle: {candle.OpenTime} - O:{candle.OpenPrice} H:{candle.HighPrice} L:{candle.LowPrice} C:{candle.ClosePrice} V:{candle.TotalVolume}");
 };
@@ -39,7 +39,7 @@ _connector.SubscriptionOnline += (sub) =>
 {
 	if (sub != subscription)
 		return;
-		
+
 	Console.WriteLine("Subscription switched to real-time mode");
 };
 
@@ -48,7 +48,7 @@ _connector.SubscriptionFailed += (sub, error, isSubscribe) =>
 {
 	if (sub != subscription)
 		return;
-		
+
 	Console.WriteLine($"Subscription error: {error}");
 };
 
@@ -67,7 +67,7 @@ _connector.OrderBookReceived += (sub, depth) =>
 {
 	if (sub != depthSubscription)
 		return;
-		
+
 	// Process the order book
 	Console.WriteLine($"Order book: {depth.SecurityId}, Time: {depth.ServerTime}");
 	Console.WriteLine($"Bids: {depth.Bids.Count}, Asks: {depth.Asks.Count}");
@@ -88,7 +88,7 @@ _connector.TickTradeReceived += (sub, tick) =>
 {
 	if (sub != tickSubscription)
 		return;
-		
+
 	// Process the tick
 	Console.WriteLine($"Tick: {tick.SecurityId}, Time: {tick.ServerTime}, Price: {tick.Price}, Volume: {tick.Volume}");
 };
@@ -127,9 +127,9 @@ _connector.Level1Received += (sub, level1) =>
 {
 	if (sub != level1Subscription)
 		return;
-	
+
 	Console.WriteLine($"Level1: {level1.SecurityId}, Time: {level1.ServerTime}");
-	
+
 	// Output Level1 field values
 	foreach (var pair in level1.Changes)
 	{

--- a/ru/topics/api/market_data/getting_historical_data.md
+++ b/ru/topics/api/market_data/getting_historical_data.md
@@ -33,7 +33,7 @@ connector.Connect();
 ```cs
 // Создаем подписку на 5-минутные свечи для выбранного инструмента
 var subscription = new Subscription(
-	DataType.TimeFrame(TimeSpan.FromMinutes(5)), 
+	DataType.TimeFrame(TimeSpan.FromMinutes(5)),
 	security)
 {
 	MarketData =
@@ -58,10 +58,10 @@ private void OnCandleReceived(Subscription subscription, ICandleMessage candle)
 	// Проверяем, что свеча относится к нашей подписке
 	if (subscription != _subscription)
 		return;
-		
+
 	// Обрабатываем полученную свечу
 	Console.WriteLine($"Получена свеча: {candle.OpenTime}, O:{candle.OpenPrice}, H:{candle.HighPrice}, L:{candle.LowPrice}, C:{candle.ClosePrice}, V:{candle.TotalVolume}");
-	
+
 	// Для отображения на графике можно использовать:
 	// Chart.Draw(_candleElement, candle);
 }
@@ -87,7 +87,7 @@ private void OnCandleReceived(Subscription subscription, ICandleMessage candle)
 	// Проверяем, что свеча относится к нашей подписке
 	if (subscription != _subscription)
 		return;
-		
+
 	// Если нужно отображать только завершенные свечи
 	if (candle.State == CandleStates.Finished)
 	{

--- a/ru/topics/api/market_data/getting_news_data.md
+++ b/ru/topics/api/market_data/getting_news_data.md
@@ -24,18 +24,18 @@ private void OnNewsReceived(Subscription subscription, News news)
 {
 	if (subscription != newsSubscription)
 		return;
-		
+
 	// Обрабатываем полученную новость
 	Console.WriteLine($"Новость: {news.Id}");
 	Console.WriteLine($"Заголовок: {news.Headline}");
 	Console.WriteLine($"Источник: {news.Source}");
 	Console.WriteLine($"Время: {news.ServerTime}");
 	Console.WriteLine($"Ссылка: {news.Url}");
-	
+
 	// Если есть текст новости
 	if (!string.IsNullOrEmpty(news.Story))
 		Console.WriteLine($"Текст: {news.Story}");
-	
+
 	// Если новость связана с конкретными инструментами
 	if (news.SecurityId != null)
 		Console.WriteLine($"Инструмент: {news.SecurityId}");
@@ -50,11 +50,11 @@ private void OnNewsReceived(Subscription subscription, News news)
 // Создаем подписку на новости с фильтрацией
 var filteredNewsSubscription = new Subscription(DataType.News)
 {
-	MarketData = 
+	MarketData =
 	{
 		// Указываем период, за который нужно получить новости
 		From = DateTime.Now.Subtract(TimeSpan.FromHours(24)),
-		
+
 		// Можно указать конкретный источник новостей
 		// Для примера используем RSS источник
 		NewsSource = "CryptoNews"
@@ -73,9 +73,9 @@ StockSharp предоставляет специальный визуальны�
 var newsPanel = new NewsPanel();
 
 // Подписываемся на событие получения новостей и добавляем их в панель
-_connector.NewsReceived += (subscription, news) => 
+_connector.NewsReceived += (subscription, news) =>
 {
-	// Для обновления элементов пользовательского интерфейса 
+	// Для обновления элементов пользовательского интерфейса
 	// нужно использовать метод GuiAsync или GuiSync
 	this.GuiAsync(() => newsPanel.NewsGrid.News.Add(news));
 };
@@ -95,7 +95,7 @@ _connector.NewsReceived += (subscription, news) =>
 // Создаем подписку на исторические новости
 var historicalNewsSubscription = new Subscription(DataType.News)
 {
-	MarketData = 
+	MarketData =
 	{
 		// Указываем период, за который нужно получить новости
 		From = DateTime.Now.Subtract(TimeSpan.FromDays(7)),

--- a/ru/topics/api/market_data/subscriptions.md
+++ b/ru/topics/api/market_data/subscriptions.md
@@ -29,7 +29,7 @@ _connector.CandleReceived += (sub, candle) =>
 {
 	if (sub != subscription)
 		return;
-		
+
 	// Обработка свечи
 	Console.WriteLine($"Свеча: {candle.OpenTime} - O:{candle.OpenPrice} H:{candle.HighPrice} L:{candle.LowPrice} C:{candle.ClosePrice} V:{candle.TotalVolume}");
 };
@@ -39,7 +39,7 @@ _connector.SubscriptionOnline += (sub) =>
 {
 	if (sub != subscription)
 		return;
-		
+
 	Console.WriteLine("Подписка перешла в режим реального времени");
 };
 
@@ -48,7 +48,7 @@ _connector.SubscriptionFailed += (sub, error, isSubscribe) =>
 {
 	if (sub != subscription)
 		return;
-		
+
 	Console.WriteLine($"Ошибка подписки: {error}");
 };
 
@@ -67,7 +67,7 @@ _connector.OrderBookReceived += (sub, depth) =>
 {
 	if (sub != depthSubscription)
 		return;
-		
+
 	// Обработка стакана
 	Console.WriteLine($"Стакан: {depth.SecurityId}, Время: {depth.ServerTime}");
 	Console.WriteLine($"Покупки (Bids): {depth.Bids.Count}, Продажи (Asks): {depth.Asks.Count}");
@@ -88,7 +88,7 @@ _connector.TickTradeReceived += (sub, tick) =>
 {
 	if (sub != tickSubscription)
 		return;
-		
+
 	// Обработка тика
 	Console.WriteLine($"Тик: {tick.SecurityId}, Время: {tick.ServerTime}, Цена: {tick.Price}, Объем: {tick.Volume}");
 };
@@ -127,9 +127,9 @@ _connector.Level1Received += (sub, level1) =>
 {
 	if (sub != level1Subscription)
 		return;
-	
+
 	Console.WriteLine($"Level1: {level1.SecurityId}, Время: {level1.ServerTime}");
-	
+
 	// Вывод значений полей Level1
 	foreach (var pair in level1.Changes)
 	{


### PR DESCRIPTION
## Summary
- clean up trailing whitespace in `api/market_data` docs
- add newline at end of file for consistency

## Testing
- `grep -n " \+$" -r en/topics/api/market_data | head`


------
https://chatgpt.com/codex/tasks/task_e_6860eeb5f3a48323b434b10e613dd993