### PR TITLE
Fix grammar in options docs

### DIFF
--- a/en/topics/api/options/delta_hedging.md
+++ b/en/topics/api/options/delta_hedging.md
@@ -4,8 +4,8 @@ If you want to protect positions by option strategies (for example, as [Volatili
 
 ## Delta hedging
 
-1. As a demonstration of the [DeltaHedgeStrategy](xref:StockSharp.Algo.Strategies.Derivatives.DeltaHedgeStrategy) work the SampleOptionQuoting example is modified (for details see [Volatility trading](volatility_trading.md)). 
-2. The [VolatilityQuotingStrategy](xref:StockSharp.Algo.Strategies.Derivatives.VolatilityQuotingStrategy) strategy does not start, but instead it is passed as a child, for the [DeltaHedgeStrategy](xref:StockSharp.Algo.Strategies.Derivatives.DeltaHedgeStrategy) strategy. 
+1. As a demonstration of how the [DeltaHedgeStrategy](xref:StockSharp.Algo.Strategies.Derivatives.DeltaHedgeStrategy) works, the SampleOptionQuoting example is modified (for details see [Volatility trading](volatility_trading.md)).
+2. The [VolatilityQuotingStrategy](xref:StockSharp.Algo.Strategies.Derivatives.VolatilityQuotingStrategy) strategy does not start, but instead it is passed as a child strategy to the [DeltaHedgeStrategy](xref:StockSharp.Algo.Strategies.Derivatives.DeltaHedgeStrategy).
 
    ```cs
    // create delta hedge strategy
@@ -25,9 +25,9 @@ If you want to protect positions by option strategies (for example, as [Volatili
    	Portfolio = Portfolio.SelectedPortfolio,
    	Connector = Connector,
    };
-   // link quoting and hending
+   // link quoting and hedging
    hedge.ChildStrategies.Add(quoting);
-   // start henging
+   // start hedging
    hedge.Start();
    ```
 

--- a/en/topics/api/options/greeks.md
+++ b/en/topics/api/options/greeks.md
@@ -15,4 +15,4 @@ decimal rho = bs.Rho(currentTime);
 decimal iv = bs.ImpliedVolatility(currentTime, premium);  // premium is premium of the option contract
 ```
 
-In addition the installation package includes the OptionCalculator example, in which all the “Greeks” are calculated and visualized using the [OptionDesk](xref:StockSharp.Xaml.OptionDesk) graphical component. See [Graphic components](graphic_components.md). 
+In addition, the installation package includes the OptionCalculator example, in which all the “Greeks” are calculated and visualized using the [OptionDesk](xref:StockSharp.Xaml.OptionDesk) graphical component. See [Graphic components](graphic_components.md).

--- a/en/topics/api/options/volatility_trading.md
+++ b/en/topics/api/options/volatility_trading.md
@@ -1,11 +1,11 @@
 # Volatility trading
 
-For the option quoting the special [VolatilityQuotingStrategy](xref:StockSharp.Algo.Strategies.Derivatives.VolatilityQuotingStrategy) strategy is realized, which provides the volume quoting by the specified range of volatility. 
+For option quoting, a special [VolatilityQuotingStrategy](xref:StockSharp.Algo.Strategies.Derivatives.VolatilityQuotingStrategy) strategy is implemented, which provides volume quoting within the specified range of volatility.
 
 ## Quoting by volatility
 
-1. The [S\#](../../api.md) installation package includes the example SampleOptionQuoting, which quotes selected strike by the specified range of volatility. 
-2. Creating a connection to the [OpenECry](../connectors/stock_market/openecry.md) and export starting: 
+1. The [S\#](../../api.md) installation package includes the example SampleOptionQuoting, which quotes the selected strike within the specified range of volatility.
+2. Creating a connection to the [OpenECry](../connectors/stock_market/openecry.md) and starting the export:
 
    ```cs
    private void InitConnector()
@@ -123,9 +123,9 @@ For the option quoting the special [VolatilityQuotingStrategy](xref:StockSharp.A
    		Portfolio = Portfolio.SelectedPortfolio,
    		Connector = Connector,
    	};
-   	// link quoting and hending
+        // link quoting and hedging
    	hedge.ChildStrategies.Add(quoting);
-   	// start henging
+        // start hedging
    	hedge.Start();
    	wnd.Closed += (s1, e1) =>
    	{
@@ -137,7 +137,7 @@ For the option quoting the special [VolatilityQuotingStrategy](xref:StockSharp.A
    }
    ```
 
-4. The quoting start: 
+4. Starting quoting:
 
    ```cs
    hedge.Start();
@@ -154,7 +154,7 @@ For the option quoting the special [VolatilityQuotingStrategy](xref:StockSharp.A
 
    ![sample quote iv](../../../images/sample_quote_iv.png)
 
-6. The quoting ending and the strategy stop: 
+6. Ending quoting and stopping the strategy:
 
    ```none
    hedge.Stop();

--- a/ru/topics/api/options/delta_hedging.md
+++ b/ru/topics/api/options/delta_hedging.md
@@ -5,7 +5,7 @@
 ## Дельта хеджирование
 
 1. В качестве демонстрации работы [DeltaHedgeStrategy](xref:StockSharp.Algo.Strategies.Derivatives.DeltaHedgeStrategy) изменен пример SampleOptionQuoting (подробнее, [Котирование по волатильности](volatility_trading.md)). 
-2. Сама стратегия [VolatilityQuotingStrategy](xref:StockSharp.Algo.Strategies.Derivatives.VolatilityQuotingStrategy) не запускается, а вместо этого она передается в качестве дочерней, для стратегии [DeltaHedgeStrategy](xref:StockSharp.Algo.Strategies.Derivatives.DeltaHedgeStrategy)
+2. Сама стратегия [VolatilityQuotingStrategy](xref:StockSharp.Algo.Strategies.Derivatives.VolatilityQuotingStrategy) не запускается, а вместо этого она передается в качестве дочерней для стратегии [DeltaHedgeStrategy](xref:StockSharp.Algo.Strategies.Derivatives.DeltaHedgeStrategy)
 
    ```cs
    // Создаем Дельта-хедж стратегию

--- a/ru/topics/api/options/greeks.md
+++ b/ru/topics/api/options/greeks.md
@@ -15,4 +15,4 @@ decimal rho = bs.Rho(currentTime);
 decimal iv = bs.ImpliedVolatility(currentTime, premium);  // где premium - премия по опциону
 ```
 
-Кроме того в дистрибутив входит пример OptionCalculator, в котором рассчитываются и визуализируются все "греки" при помощи графического компонента [OptionDesk](xref:StockSharp.Xaml.OptionDesk). См. [Графические компоненты для опционов](graphic_components.md). 
+Кроме того, в дистрибутив входит пример OptionCalculator, в котором рассчитываются и визуализируются все "греки" при помощи графического компонента [OptionDesk](xref:StockSharp.Xaml.OptionDesk). См. [Графические компоненты для опционов](graphic_components.md).

--- a/ru/topics/api/options/volatility_trading.md
+++ b/ru/topics/api/options/volatility_trading.md
@@ -122,9 +122,9 @@
    		Portfolio = Portfolio.SelectedPortfolio,
    		Connector = Connector,
    	};
-   	// link quoting and hending
+        // link quoting and hedging
    	hedge.ChildStrategies.Add(quoting);
-   	// start henging
+        // start hedging
    	hedge.Start();
    	wnd.Closed += (s1, e1) =>
    	{


### PR DESCRIPTION
## Summary
- clean up grammar in RU options docs
- tweak phrasing and fix typos in EN options docs

## Testing
- `python tabify_code_blocks.py --help` *(fails: FileNotFoundError)*
- `python tabify_code_blocks.py`

------
https://chatgpt.com/codex/tasks/task_e_6860eec5c52483238031e72127e79683