### PR TITLE
Fix grammar issues in shell docs

### DIFF
--- a/en/topics/shell/create_strategy_panel.md
+++ b/en/topics/shell/create_strategy_panel.md
@@ -17,7 +17,7 @@ Replace `UserControl` with `controls:BaseStudioControl`.
 	  				
 ```
 
-Then implement your own panel logic by analogy with the existing strategy panels.
+Then implement your own panel logic similar to the existing strategy panels.
 
 In order for the [Real\-time](user_interface/real_time.md) panel to see the strategy in your panel, your strategy must be set as a property:
 

--- a/en/topics/shell/quick_start.md
+++ b/en/topics/shell/quick_start.md
@@ -1,6 +1,6 @@
 # Quick start
 
-[Shell](../shell.md) \- \- is focused on programming in [C\#](https://en.wikipedia.org/wiki/C_Sharp_(programming_language)) language in Visual Studio environment or similar.
+[Shell](../shell.md) - is focused on programming in [C\#](https://en.wikipedia.org/wiki/C_Sharp_(programming_language)) language in Visual Studio environment or similar.
 
 When you start the [Shell](../shell.md) project, the Solution Explorer displays the Shell project:
 

--- a/ru/topics/shell/create_strategy.md
+++ b/ru/topics/shell/create_strategy.md
@@ -4,7 +4,7 @@
 
 ![Shell custom strategy 00](../../images/shell_custom_strategy_00.png)
 
-Воспользовавшись примером стратегии SmaStrategy необходимо создать саму стратегию.
+Воспользовавшись примером стратегии SmaStrategy, необходимо создать саму стратегию.
 
 Если для стратегии необходимо добавить собственную панель тестирования или мониторинга, то стратегия должна реализовать интерфейсы IHaveTestControl и IHaveMonitoringControl соответственно. 
 
@@ -40,7 +40,7 @@ public class SmaStrategy : Strategy, IHaveMonitoringControl, IHaveTestControl
 
 ![Shell custom strategy 01](../../images/shell_custom_strategy_01.png)
 
-Чтобы созданная стратегия была доступна в окне выбора стратегий ее необходимо добавить в словарь **DictionaryStrategies** главного окна 
+Чтобы созданная стратегия была доступна в окне выбора стратегий, ее необходимо добавить в словарь **DictionaryStrategies** главного окна 
 
 ```cs
 	...
@@ -56,7 +56,7 @@ public class SmaStrategy : Strategy, IHaveMonitoringControl, IHaveTestControl
 		
 ```
 
-Для того чтобы стратегия сохранялась и после этого загружалась, в конструкторе стратегии необходимо установить параметр стратегии
+Для того чтобы стратегия сохранялась и после этого загружалась, в конструкторе стратегии необходимо установить параметр стратегии.
 
 ```cs
 public class SmaStrategy : Strategy, IHaveMonitoringControl, IHaveTestControl

--- a/ru/topics/shell/quick_start.md
+++ b/ru/topics/shell/quick_start.md
@@ -24,14 +24,14 @@
 
 ![Shell Quick start 02](../../images/shell_quick_start_02.png)
 
-Перейдя на вкладку Реал\-тайм нажав на кнопку **Добавить** ![Designer Creation tool 00](../../images/designer_creation_tool_00.png) добавим стратегию для запуска в торговлю.
+Перейдя на вкладку Реал\-тайм, нажав на кнопку **Добавить** ![Designer Creation tool 00](../../images/designer_creation_tool_00.png) добавим стратегию для запуска в торговлю.
 
 ![Shell Quick start 03](../../images/shell_quick_start_03.png)
 
-После того как стратегия будет добавлена необходимо заполнить ее основные параметры такие как **Инструмент**, **Портфель** и др. Для запуска необходимо нажать на кнопку **Start strategy**.
+После того как стратегия будет добавлена, необходимо заполнить ее основные параметры, такие как **Инструмент**, **Портфель** и др. Для запуска необходимо нажать на кнопку **Start strategy**.
 
 ![Shell Quick start 04](../../images/shell_quick_start_04.png)
 
-Аналогично вкладке [Реал\-тайм](user_interface/real_time.md) на вкладке [Эмуляция](user_interface/emulation.md) можно запустить тестирование стратегии на исторических данных
+Аналогично вкладке [Реал\-тайм](user_interface/real_time.md) на вкладке [Эмуляция](user_interface/emulation.md) можно запустить тестирование стратегии на исторических данных.
 
 ![Shell Quick start 05](../../images/shell_quick_start_05.png)


### PR DESCRIPTION
## Summary
- add missing commas and periods in Russian quick start and strategy docs
- clean up dash in English quick start
- reword English strategy panel guidance

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860ee6e5890832398a66ca5e5bdd8d0