### PR TITLE
Fix Designer download text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
+![StockSharp Logo](logo.svg)
 # 🚀 StockSharp Documentation Hub 🚀
 
 Dive into our live docs at [doc.stocksharp.com](https://doc.stocksharp.com/) (or check out the Russian version at [doc.stocksharp.ru](https://doc.stocksharp.ru/)!
+Need help? Join our [Telegram chat](https://t.me/stocksharpchat/361).
 
 📢 **Join the mission!** We’re calling all passionate contributors to help us supercharge our manuals. Let’s make them clearer, richer, and more awesome together! 💪 Jump in and shape the future of StockSharp’s documentation! ✨
+
+## Running strategies
+The simplest way to run strategies is with [Designer](https://stocksharp.com/store/strategy-designer/).
+1. [Download Designer](https://stocksharp.com/store/strategy-designer/) and install it.
+2. Launch Designer.
+3. Open the **Strategy Gallery** and choose a strategy to run.
+## Resources
+- [Documentation](https://doc.stocksharp.com/)
+- [Telegram chat](https://t.me/stocksharpchat/361)
+


### PR DESCRIPTION
## Summary
- link text in `Running strategies` now anchors on "Download Designer"

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a076c5030832395687be4ae34ed20