### PR TITLE
Update strategy sample docs to highlight AlgoTrading API

### DIFF
--- a/en/topics/api/strategies/samples.md
+++ b/en/topics/api/strategies/samples.md
@@ -1,5 +1,5 @@
 # Other Strategy Examples
 
-All strategy examples can be found in the [Samples](https://github.com/StockSharp/StockSharp/tree/master/Samples/06_Strategies) folder, as well as in the [Algo/Strategies](https://github.com/StockSharp/StockSharp/tree/master/Algo/Strategies) folder.
+Hundreds of strategy samples written in C# and Python are maintained in the [AlgoTrading API folder](https://github.com/StockSharp/AlgoTrading/tree/main/API). This link appears first on the page. All of these strategies are also compatible with the [Designer](../../designer.md).
 
-The main repository for regularly updated strategies is [AlgoTrading](https://github.com/StockSharp/AlgoTrading). In this repository, strategies compatible with the [Designer](../../designer.md) are periodically posted.
+Additional examples can be found in the [Samples](https://github.com/StockSharp/StockSharp/tree/master/Samples/06_Strategies) folder.

--- a/en/topics/designer/strategies/using_code.md
+++ b/en/topics/designer/strategies/using_code.md
@@ -6,6 +6,8 @@
 - [F#](using_code/fsharp.md) 
 - [Python](using_code/python.md)
 
+Extensive strategy samples in C# and Python are available in the [AlgoTrading API folder](https://github.com/StockSharp/AlgoTrading/tree/main/API). All of them work with the [Designer](../../designer.md).
+
 ## C#
 
 C# is the main language for developing trading strategies. All components, examples and core code are written in C#. C# provides full access to the entire [S#](../../api.md) platform architecture.

--- a/ru/topics/api/strategies/samples.md
+++ b/ru/topics/api/strategies/samples.md
@@ -1,5 +1,5 @@
 # Другие примеры стратегий
 
-Все примеры стратегий находятся в папке [Samples](https://github.com/StockSharp/StockSharp/tree/master/Samples/06_Strategies), а также в папке [Algo/Strategies](https://github.com/StockSharp/StockSharp/tree/master/Algo/Strategies).
+Сотни примеров стратегий на C# и Python размещены в [папке API](https://github.com/StockSharp/AlgoTrading/tree/main/API) репозитория [AlgoTrading](https://github.com/StockSharp/AlgoTrading). Эта ссылка указана первой на странице. Все они совместимы с [Дизайнером](../../designer.md).
 
-Основной репозиторий для постоянного обновления стратегий — это [AlgoTrading](https://github.com/StockSharp/AlgoTrading). В этом репозитории периодически выкладываются стратегии, совместимые с [Дизайнером](../../designer.md).
+Дополнительные примеры находятся в папке [Samples](https://github.com/StockSharp/StockSharp/tree/master/Samples/06_Strategies).

--- a/ru/topics/designer/strategies/using_code.md
+++ b/ru/topics/designer/strategies/using_code.md
@@ -6,6 +6,8 @@
 - [F#](using_code/fsharp.md)
 - [Python](using_code/python.md)
 
+Обширные примеры стратегий на C# и Python находятся в [папке API](https://github.com/StockSharp/AlgoTrading/tree/main/API) репозитория [AlgoTrading](https://github.com/StockSharp/AlgoTrading). Все они работают с [Дизайнером](../../designer.md).
+
 ## C#
 
 C# является основным языком разработки торговых стратегий. Все компоненты, примеры и основной код написаны на C#. C# предоставляет полный доступ ко всей архитектуре платформы [S#](../../api.md).


### PR DESCRIPTION
## Summary
- revise samples pages
- emphasize the AlgoTrading repository API folder containing hundreds of C# and Python strategies, all compatible with Designer
- mention the same repo in Designer docs

## Testing
- `python3 increase_links.py --help` *(fails: FileNotFoundError)*
- `python3 tabify_code_blocks.py --help` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68766cb7341883238203c28dfd64a30b