### PR TITLE
Fix Bollinger Band examples

### DIFF
--- a/en/topics/api/strategies/samples/bollinger_classic.md
+++ b/en/topics/api/strategies/samples/bollinger_classic.md
@@ -48,7 +48,7 @@ protected override void OnStarted(DateTimeOffset time)
 	// Create subscription and bind indicator
 	var subscription = SubscribeCandles(CandleType);
 	subscription
-		.Bind(_bollingerBands, ProcessCandle)
+		.BindEx(_bollingerBands, ProcessCandle)
 		.Start();
 
 	// Set up visualization on the chart
@@ -67,7 +67,7 @@ protected override void OnStarted(DateTimeOffset time)
 The `ProcessCandle` method is called for each completed candle and implements the trading logic:
 
 ```cs
-private void ProcessCandle(ICandleMessage candle, decimal middleBand, decimal upperBand, decimal lowerBand)
+private void ProcessCandle(ICandleMessage candle, IIndicatorValue bollingerValue)
 {
 	// Skip incomplete candles
 	if (candle.State != CandleStates.Finished)
@@ -77,14 +77,16 @@ private void ProcessCandle(ICandleMessage candle, decimal middleBand, decimal up
 	if (!IsFormedAndOnlineAndAllowTrading())
 		return;
 
+	var typed = (BollingerBandsValue)bollingerValue;
+
 	// Trading logic:
 	// Sell when price reaches or exceeds the upper band
-	if (candle.ClosePrice >= upperBand && Position >= 0)
+	if (candle.ClosePrice >= typed.UpBand && Position >= 0)
 	{
 		SellMarket(Volume + Math.Abs(Position));
 	}
 	// Buy when price reaches or falls below the lower band
-	else if (candle.ClosePrice <= lowerBand && Position <= 0)
+	else if (candle.ClosePrice <= typed.LowBand && Position <= 0)
 	{
 		BuyMarket(Volume + Math.Abs(Position));
 	}

--- a/en/topics/api/strategies/samples/bollinger_up.md
+++ b/en/topics/api/strategies/samples/bollinger_up.md
@@ -48,7 +48,7 @@ protected override void OnStarted(DateTimeOffset time)
 	// Create subscription and bind indicator
 	var subscription = SubscribeCandles(CandleType);
 	subscription
-		.Bind(_bollingerBands, ProcessCandle)
+		.BindEx(_bollingerBands, ProcessCandle)
 		.Start();
 
 	// Set up visualization on the chart
@@ -67,7 +67,7 @@ protected override void OnStarted(DateTimeOffset time)
 The `ProcessCandle` method is called for each completed candle and implements the trading logic:
 
 ```cs
-private void ProcessCandle(ICandleMessage candle, decimal middleBand, decimal upperBand, decimal lowerBand)
+private void ProcessCandle(ICandleMessage candle, IIndicatorValue bollingerValue)
 {
 	// Skip incomplete candles
 	if (candle.State != CandleStates.Finished)
@@ -77,14 +77,16 @@ private void ProcessCandle(ICandleMessage candle, decimal middleBand, decimal up
 	if (!IsFormedAndOnlineAndAllowTrading())
 		return;
 
+	var typed = (BollingerBandsValue)bollingerValue;
+
 	// Trading logic:
 	// Buy when price touches the upper band (only when no position exists)
-	if (candle.ClosePrice >= upperBand && Position == 0)
+	if (candle.ClosePrice >= typed.UpBand && Position == 0)
 	{
 		BuyMarket(Volume);
 	}
 	// Sell to close the position when price reaches the middle line (only with a long position)
-	else if (candle.ClosePrice <= middleBand && Position > 0)
+	else if (candle.ClosePrice <= typed.MiddleBand && Position > 0)
 	{
 		SellMarket(Math.Abs(Position));
 	}

--- a/ru/topics/api/strategies/samples/bollinger_low.md
+++ b/ru/topics/api/strategies/samples/bollinger_low.md
@@ -48,7 +48,7 @@ protected override void OnStarted(DateTimeOffset time)
 	// Создание подписки и привязка индикатора
 	var subscription = SubscribeCandles(CandleType);
 	subscription
-		.Bind(_bollingerBands, ProcessCandle)
+		.BindEx(_bollingerBands, ProcessCandle)
 		.Start();
 
 	// Настройка визуализации на графике
@@ -67,7 +67,7 @@ protected override void OnStarted(DateTimeOffset time)
 Метод `ProcessCandle` вызывается для каждой завершенной свечи и реализует торговую логику:
 
 ```cs
-private void ProcessCandle(ICandleMessage candle, decimal middleBand, decimal upperBand, decimal lowerBand)
+private void ProcessCandle(ICandleMessage candle, IIndicatorValue bollingerValue)
 {
 	// Пропускаем незавершенные свечи
 	if (candle.State != CandleStates.Finished)
@@ -77,14 +77,16 @@ private void ProcessCandle(ICandleMessage candle, decimal middleBand, decimal up
 	if (!IsFormedAndOnlineAndAllowTrading())
 		return;
 
+	var typed = (BollingerBandsValue)bollingerValue;
+
 	// Торговая логика:
 	// Продажа, когда цена касается нижней полосы (только при отсутствии позиции)
-	if (candle.ClosePrice <= lowerBand && Position == 0)
+	if (candle.ClosePrice <= typed.LowBand && Position == 0)
 	{
 		SellMarket(Volume);
 	}
 	// Покупка для закрытия позиции, когда цена достигает средней линии (только при наличии короткой позиции)
-	else if (candle.ClosePrice >= middleBand && Position < 0)
+	else if (candle.ClosePrice >= typed.MiddleBand && Position < 0)
 	{
 		BuyMarket(Math.Abs(Position));
 	}


### PR DESCRIPTION
## Summary
- update Bollinger Bands samples to use `BindEx`
- pass `IIndicatorValue` to `ProcessCandle` and cast to `BollingerBandsValue`
- fix indentation in Bollinger samples

## Testing
- `python3 tabify_code_blocks.py en/topics/api/strategies/samples/bollinger_low.md en/topics/api/strategies/samples/bollinger_up.md en/topics/api/strategies/samples/bollinger_classic.md ru/topics/api/strategies/samples/bollinger_low.md ru/topics/api/strategies/samples/bollinger_up.md ru/topics/api/strategies/samples/bollinger_classic.md`

------
https://chatgpt.com/codex/tasks/task_e_68768227b6a083239585a6f16316aef3