### PR TITLE
Update docs for order loading with CanAttach

### DIFF
--- a/en/topics/api/strategies/orders_and_trades_loading.md
+++ b/en/topics/api/strategies/orders_and_trades_loading.md
@@ -2,53 +2,43 @@
 
 When starting a strategy, it may be necessary to load previously executed orders and trades (for example, when a robot was restarted during a trading session or when orders and trades are carried over overnight). To do this, you need to:
 
-1. Find the orders that need to be loaded into the strategy and return them from a method (for example, load order IDs if the strategy records them each time during registration through the [Strategy.ProcessNewOrders](xref:StockSharp.Algo.Strategies.Strategy.ProcessNewOrders(System.Collections.Generic.IEnumerable{StockSharp.BusinessEntities.Order}))**(**[System.Collections.Generic.IEnumerable\<StockSharp.BusinessEntities.Order\>](xref:System.Collections.Generic.IEnumerable`1) newOrders **)** method from a file).
-2. Combine the obtained result with the base method [Strategy.ProcessNewOrders](xref:StockSharp.Algo.Strategies.Strategy.ProcessNewOrders(System.Collections.Generic.IEnumerable{StockSharp.BusinessEntities.Order}))**(**[System.Collections.Generic.IEnumerable\<StockSharp.BusinessEntities.Order\>](xref:System.Collections.Generic.IEnumerable`1) newOrders **)**.
-3. After the orders are loaded into the strategy, all trades executed on them will also be loaded. This will be done automatically.
+1. Load the transaction IDs of orders saved earlier (for example, from a file).
+2. Subscribe to the `OrderReceived` event to record new transaction IDs for future sessions.
+3. Override the `CanAttach` method to associate previously placed orders with the strategy.
+4. After the orders are attached to the strategy, all trades executed on them will be loaded automatically.
 
 The following example shows how to load all trades into a strategy:
 
 ## Loading Previously Executed Orders and Trades into a Strategy
 
-1. For [Strategy](xref:StockSharp.Algo.Strategies.Strategy) to load its previous state, you need to override [Strategy.ProcessNewOrders](xref:StockSharp.Algo.Strategies.Strategy.ProcessNewOrders(System.Collections.Generic.IEnumerable{StockSharp.BusinessEntities.Order}))**(**[System.Collections.Generic.IEnumerable\<StockSharp.BusinessEntities.Order\>](xref:System.Collections.Generic.IEnumerable`1) newOrders **)**. This method will receive all orders from the connector during [Strategy.OnStarted](xref:StockSharp.Algo.Strategies.Strategy.OnStarted), and you need to filter them:
+1. When the strategy starts, load saved transaction numbers and subscribe to `OrderReceived` to store new ones:
 
 ```cs
-	private bool _isOrdersLoaded;
-	private bool _isStopOrdersLoaded;
-			  	
-	protected override IEnumerable<Order> ProcessNewOrders(IEnumerable<Order> newOrders, bool isStopOrders)
-	{
-		// if orders have already been loaded previously
-		if ((!isStopOrders && _isOrdersLoaded) || (isStopOrders && _isStopOrdersLoaded))
-			return base.ProcessNewOrders(newOrders, isStopOrders);
-		return Filter(newOrders);
-	}
+private HashSet<long> _transactions;
+
+protected override void OnStarted(DateTimeOffset time)
+{
+		base.OnStarted(time);
+
+		_transactions = File.Exists($"orders_{Name}.txt")
+				? File.ReadAllLines($"orders_{Name}.txt").Select(l => l.To<long>()).ToHashSet()
+				: new HashSet<long>();
+
+		OrderReceived += order =>
+		{
+				File.AppendAllLines($"orders_{Name}.txt", new[] { order.TransactionId.ToString() });
+				_transactions.Add(order.TransactionId);
+		};
+}
 ```
 
-2. To implement order filtering, you need to define a screening criterion. For example, if during the strategy operation you save all registered orders to a file, you can create a filter by transaction number [Order.TransactionId](xref:StockSharp.BusinessEntities.Order.TransactionId). If such a number is present in the file, it means the order was registered through this strategy:
+2. Override `CanAttach` so the strategy can recognize its orders after a restart:
 
 ```cs
-	private IEnumerable<Order> Filter(IEnumerable<Order> orders)
-	{
-		// read transaction numbers from the file
-		var transactions = File.ReadAllLines("orders_{0}.txt".Put(Name)).Select(l => l.To<long>()).ToArray();
-		
-		// find our orders by the read numbers
-		return orders.Where(o => transactions.Contains(o.TransactionId));
-	}
+protected override bool CanAttach(Order order)
+{
+		return _transactions.Contains(order.TransactionId);
+}
 ```
 
-3. Recording transaction numbers of orders registered through the strategy can be done by overriding the [Strategy.RegisterOrder](xref:StockSharp.Algo.Strategies.Strategy.RegisterOrder(StockSharp.BusinessEntities.Order))**(**[StockSharp.BusinessEntities.Order](xref:StockSharp.BusinessEntities.Order) order **)** method:
-
-```cs
-	protected override void RegisterOrder(Order order)
-	{
-		// send the order further for registration
-		base.RegisterOrder(order);
-		
-		// add a new transaction number
-		File.AppendAllLines("orders_{0}.txt".Put(Name), new[]{ order.TransactionId.ToString() });
-	}
-```
-
-4. After the orders are loaded into the strategy, all trades executed on them will also be loaded. This will be done automatically.
+3. After the orders are loaded into the strategy, all trades executed on them will also be loaded automatically.

--- a/ru/topics/api/strategies/orders_and_trades_loading.md
+++ b/ru/topics/api/strategies/orders_and_trades_loading.md
@@ -2,53 +2,43 @@
 
 При старте стратегии может возникнуть необходимость загрузки ранее совершённых заявок и сделок (например, когда робот был перезагружен в течение торговой сессии или сделки и заявки переносятся через ночь). Для этого нужно: 
 
-1. Найти те заявки, которые необходимо загрузить в стратегию, и вернуть их из метода (например, загрузить идентификаторы заявок, если стратегия записывает каждый раз при регистрации через метод [Strategy.ProcessNewOrders](xref:StockSharp.Algo.Strategies.Strategy.ProcessNewOrders(System.Collections.Generic.IEnumerable{StockSharp.BusinessEntities.Order}))**(**[System.Collections.Generic.IEnumerable\<StockSharp.BusinessEntities.Order\>](xref:System.Collections.Generic.IEnumerable`1) newOrders **)** из файла). 
-2. Объединить полученный результат с базовым методом [Strategy.ProcessNewOrders](xref:StockSharp.Algo.Strategies.Strategy.ProcessNewOrders(System.Collections.Generic.IEnumerable{StockSharp.BusinessEntities.Order}))**(**[System.Collections.Generic.IEnumerable\<StockSharp.BusinessEntities.Order\>](xref:System.Collections.Generic.IEnumerable`1) newOrders **)**. 
-3. После того, как заявки будут загружены в стратегию, загрузятся и все совершенные по ним сделки. Это будет сделано автоматически. 
+1. Загрузить номера транзакций заявок, которые ранее сохранила стратегия (например, из файла).
+2. Подписаться на событие `OrderReceived` и сохранять новые номера транзакций для последующих запусков.
+3. Переопределить метод `CanAttach`, чтобы после перезапуска стратегия смогла распознать свои заявки.
+4. После присоединения заявок к стратегии все совершённые по ним сделки загрузятся автоматически.
 
 Следующий пример показывает загрузку всех сделок в стратегию: 
 
 ## Загрузка в стратегию ранее совершенных заявок и сделок
 
-1. Для этого, чтобы [Strategy](xref:StockSharp.Algo.Strategies.Strategy) загрузила свое предыдущее состояние, необходимо переопределить [Strategy.ProcessNewOrders](xref:StockSharp.Algo.Strategies.Strategy.ProcessNewOrders(System.Collections.Generic.IEnumerable{StockSharp.BusinessEntities.Order}))**(**[System.Collections.Generic.IEnumerable\<StockSharp.BusinessEntities.Order\>](xref:System.Collections.Generic.IEnumerable`1) newOrders **)**. На вход данному методу из [Strategy.OnStarted](xref:StockSharp.Algo.Strategies.Strategy.OnStarted) поступят все заявки из коннектора, и их необходимо отфильтровать:
+1. При старте стратегии загрузите сохранённые номера транзакций и подпишитесь на `OrderReceived`, чтобы сохранять новые номера:
 
 ```cs
-	private bool _isOrdersLoaded;
-	private bool _isStopOrdersLoaded;
-			  	
-	protected override IEnumerable<Order> ProcessNewOrders(IEnumerable<Order> newOrders, bool isStopOrders)
-	{
-		// если заявки уже были ранее загружены
-		if ((!isStopOrders && _isOrdersLoaded) || (isStopOrders && _isStopOrdersLoaded))
-			return base.ProcessNewOrders(newOrders, isStopOrders);
-		return Filter(newOrders);
-	}
+private HashSet<long> _transactions;
+
+protected override void OnStarted(DateTimeOffset time)
+{
+		base.OnStarted(time);
+
+		_transactions = File.Exists($"orders_{Name}.txt")
+				? File.ReadAllLines($"orders_{Name}.txt").Select(l => l.To<long>()).ToHashSet()
+				: new HashSet<long>();
+
+		OrderReceived += order =>
+		{
+				File.AppendAllLines($"orders_{Name}.txt", new[] { order.TransactionId.ToString() });
+				_transactions.Add(order.TransactionId);
+		};
+}
 ```
 
-2. Чтобы реализовать фильтрацию заявок, необходимо определить критерий отсеивания. Например, если в процессе работы стратегии сохранять все регистрируемые заявки в файл, то можно сделать фильтр по номеру транзакции [Order.TransactionId](xref:StockSharp.BusinessEntities.Order.TransactionId). Если такой номер присутствует в файле, значит заявка была зарегистрирована через данную стратегию: 
+2. Переопределите `CanAttach`, чтобы после перезапуска стратегия могла определить свои заявки:
 
 ```cs
-	private IEnumerable<Order> Filter(IEnumerable<Order> orders)
-	{
-		// считываем номера транзакций из файла
-		var transactions = File.ReadAllLines("orders_{0}.txt".Put(Name)).Select(l => l.To<long>()).ToArray();
-		
-		// находим наши заявки по считанным номерам
-		return orders.Where(o => transactions.Contains(o.TransactionId));
-	}
+protected override bool CanAttach(Order order)
+{
+		return _transactions.Contains(order.TransactionId);
+}
 ```
 
-3. Запись номеров транзакций заявок, регистрируемых через стратегию, можно осуществить, переопределив метод [Strategy.RegisterOrder](xref:StockSharp.Algo.Strategies.Strategy.RegisterOrder(StockSharp.BusinessEntities.Order))**(**[StockSharp.BusinessEntities.Order](xref:StockSharp.BusinessEntities.Order) order **)**: 
-
-```cs
-	protected override void RegisterOrder(Order order)
-	{
-		// отравляем заявку дальше на регистрацию
-		base.RegisterOrder(order);
-		
-		// добавляем новый номер транзакции
-		File.AppendAllLines("orders_{0}.txt".Put(Name), new[]{ order.TransactionId.ToString() });
-	}
-```
-
-4. После того, как заявки будут загружены в стратегию, загрузятся и все совершенные по ним сделки. Это будет сделано автоматически. 
+3. После того, как заявки будут загружены в стратегию, загрузятся и все совершённые по ним сделки автоматически.


### PR DESCRIPTION
## Summary
- describe saving transaction IDs via `OrderReceived` and overriding `CanAttach`
- show updated examples in English and Russian docs

## Testing
- `python3 tabify_code_blocks.py en/topics/api/strategies/orders_and_trades_loading.md ru/topics/api/strategies/orders_and_trades_loading.md`
- `python3 increase_links.py en/topics/api/strategies/orders_and_trades_loading.md ru/topics/api/strategies/orders_and_trades_loading.md`

------
https://chatgpt.com/codex/tasks/task_e_687fecfe9d648323a1aec179aa9ec9c0