### PR TITLE
Fix BindEx cross reference in strategy docs

### DIFF
--- a/en/topics/api/strategies/high_level_api.md
+++ b/en/topics/api/strategies/high_level_api.md
@@ -50,7 +50,7 @@ data yet (`IIndicatorValue.IsEmpty` is `true`), use the
 
 #### Using BindEx to Work with Raw Indicator Values
 
-If an indicator returns non-standard values (not just numbers), you can use the [BindEx](xref:StockSharp.Algo.Strategies.ISubscriptionHandler`1.BindEx(StockSharp.Algo.Indicators.IIndicator,System.Action{`0,StockSharp.Algo.Indicators.IIndicatorValue})) method, which provides access to the original [IIndicatorValue](xref:StockSharp.Algo.Indicators.IIndicatorValue) object:
+If an indicator returns non-standard values (not just numbers), you can use the [BindEx](xref:StockSharp.Algo.Strategies.ISubscriptionHandler`1.BindEx(StockSharp.Algo.Indicators.IIndicator,System.Action{`0,StockSharp.Algo.Indicators.IIndicatorValue},System.Boolean)) method, which provides access to the original [IIndicatorValue](xref:StockSharp.Algo.Indicators.IIndicatorValue) object:
 
 ```cs
 subscription
@@ -72,7 +72,7 @@ private void OnProcessWithRawValue(ICandleMessage candle, IIndicatorValue value)
 }
 ```
 
-The [BindEx](xref:StockSharp.Algo.Strategies.ISubscriptionHandler`1.BindEx(StockSharp.Algo.Indicators.IIndicator,System.Action{`0,StockSharp.Algo.Indicators.IIndicatorValue})) method is particularly useful in the following cases:
+The [BindEx](xref:StockSharp.Algo.Strategies.ISubscriptionHandler`1.BindEx(StockSharp.Algo.Indicators.IIndicator,System.Action{`0,StockSharp.Algo.Indicators.IIndicatorValue},System.Boolean)) method is particularly useful in the following cases:
 
 - Working with indicators that return boolean values (e.g., [Fractals](xref:StockSharp.Algo.Indicators.Fractals))
 - Accessing additional properties of the indicator value type (e.g., the [IsFinal](xref:StockSharp.Algo.Indicators.IIndicatorValue.IsFinal) flag)
@@ -108,7 +108,7 @@ private void OnProcessBollinger(ICandleMessage candle, IIndicatorValue value)
 }
 ```
 
-For more flexible work, you can use [BindEx](xref:StockSharp.Algo.Strategies.ISubscriptionHandler`1.BindEx(StockSharp.Algo.Indicators.IIndicator,System.Action{`0,StockSharp.Algo.Indicators.IIndicatorValue})) with direct access to the complex indicator value:
+For more flexible work, you can use [BindEx](xref:StockSharp.Algo.Strategies.ISubscriptionHandler`1.BindEx(StockSharp.Algo.Indicators.IIndicator,System.Action{`0,StockSharp.Algo.Indicators.IIndicatorValue},System.Boolean)) with direct access to the complex indicator value:
 
 ```cs
 subscription.BindEx(bollinger, (candle, indicatorValue) =>
@@ -122,7 +122,7 @@ subscription.BindEx(bollinger, (candle, indicatorValue) =>
 });
 ```
 
-The [BindEx](xref:StockSharp.Algo.Strategies.ISubscriptionHandler`1.BindEx(StockSharp.Algo.Indicators.IIndicator,System.Action{`0,StockSharp.Algo.Indicators.IIndicatorValue})) method for complex indicators automatically:
+The [BindEx](xref:StockSharp.Algo.Strategies.ISubscriptionHandler`1.BindEx(StockSharp.Algo.Indicators.IIndicator,System.Action{`0,StockSharp.Algo.Indicators.IIndicatorValue},System.Boolean)) method for complex indicators automatically:
 
 1. Processes input data through the complex indicator
 2. Passes the resulting `IIndicatorValue` to the specified handler

--- a/ru/topics/api/strategies/high_level_api.md
+++ b/ru/topics/api/strategies/high_level_api.md
@@ -50,7 +50,7 @@ subscription
 
 #### Использование BindEx для работы с сырыми значениями индикаторов
 
-Если индикатор возвращает нестандартные значения (не просто числа), можно использовать метод [BindEx](xref:StockSharp.Algo.Strategies.ISubscriptionHandler`1.BindEx(StockSharp.Algo.Indicators.IIndicator,System.Action{`0,StockSharp.Algo.Indicators.IIndicatorValue})), который предоставляет доступ к исходному объекту [IIndicatorValue](xref:StockSharp.Algo.Indicators.IIndicatorValue):
+Если индикатор возвращает нестандартные значения (не просто числа), можно использовать метод [BindEx](xref:StockSharp.Algo.Strategies.ISubscriptionHandler`1.BindEx(StockSharp.Algo.Indicators.IIndicator,System.Action{`0,StockSharp.Algo.Indicators.IIndicatorValue},System.Boolean)), который предоставляет доступ к исходному объекту [IIndicatorValue](xref:StockSharp.Algo.Indicators.IIndicatorValue):
 
 ```cs
 subscription
@@ -72,7 +72,7 @@ private void OnProcessWithRawValue(ICandleMessage candle, IIndicatorValue value)
 }
 ```
 
-Метод [BindEx](xref:StockSharp.Algo.Strategies.ISubscriptionHandler`1.BindEx(StockSharp.Algo.Indicators.IIndicator,System.Action{`0,StockSharp.Algo.Indicators.IIndicatorValue})) особенно полезен в следующих случаях:
+Метод [BindEx](xref:StockSharp.Algo.Strategies.ISubscriptionHandler`1.BindEx(StockSharp.Algo.Indicators.IIndicator,System.Action{`0,StockSharp.Algo.Indicators.IIndicatorValue},System.Boolean)) особенно полезен в следующих случаях:
 
 - Работа с индикаторами, возвращающими логические значения (например, [Fractals](xref:StockSharp.Algo.Indicators.Fractals))
 - Доступ к дополнительным свойствам типа индикатора (например, признак [IsFinal](xref:StockSharp.Algo.Indicators.IIndicatorValue.IsFinal))
@@ -108,7 +108,7 @@ private void OnProcessBollinger(ICandleMessage candle, IIndicatorValue value)
 }
 ```
 
-Для более гибкой работы можно использовать [BindEx](xref:StockSharp.Algo.Strategies.ISubscriptionHandler`1.BindEx(StockSharp.Algo.Indicators.IIndicator,System.Action{`0,StockSharp.Algo.Indicators.IIndicatorValue})) для прямого доступа к значению комплексного индикатора:
+Для более гибкой работы можно использовать [BindEx](xref:StockSharp.Algo.Strategies.ISubscriptionHandler`1.BindEx(StockSharp.Algo.Indicators.IIndicator,System.Action{`0,StockSharp.Algo.Indicators.IIndicatorValue},System.Boolean)) для прямого доступа к значению комплексного индикатора:
 
 ```cs
 subscription.BindEx(bollinger, (candle, indicatorValue) =>
@@ -122,7 +122,7 @@ subscription.BindEx(bollinger, (candle, indicatorValue) =>
 });
 ```
 
-Метод [BindEx](xref:StockSharp.Algo.Strategies.ISubscriptionHandler`1.BindEx(StockSharp.Algo.Indicators.IIndicator,System.Action{`0,StockSharp.Algo.Indicators.IIndicatorValue})) для комплексных индикаторов автоматически:
+Метод [BindEx](xref:StockSharp.Algo.Strategies.ISubscriptionHandler`1.BindEx(StockSharp.Algo.Indicators.IIndicator,System.Action{`0,StockSharp.Algo.Indicators.IIndicatorValue},System.Boolean)) для комплексных индикаторов автоматически:
 
 1. Обрабатывает входные данные через комплексный индикатор
 2. Передает полученное значение `IIndicatorValue` в указанный обработчик


### PR DESCRIPTION
## Summary
- fix BindEx method xrefs to include optional allowEmpty parameter in Russian and English high level strategy docs

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689921ca5c208323b5253751c045f1cc