### PR TITLE
Update Hydra analytics docs with DataType examples

### DIFF
--- a/en/topics/hydra/analytics/create_own_script.md
+++ b/en/topics/hydra/analytics/create_own_script.md
@@ -10,11 +10,11 @@ namespace StockSharp.Algo.Analytics
 	/// </summary>
 	public class ChartDrawScript : IAnalyticsScript
 	{
-		Task IAnalyticsScript.Run(ILogReceiver logs, IAnalyticsPanel panel, SecurityId[] securities, DateTime from, DateTime to, IStorageRegistry storage, IMarketDataDrive drive, StorageFormats format, TimeSpan timeFrame, CancellationToken cancellationToken)
+		Task IAnalyticsScript.Run(ILogReceiver logs, IAnalyticsPanel panel, SecurityId[] securities, DateTime from, DateTime to, IStorageRegistry storage, IMarketDataDrive drive, StorageFormats format, DataType dataType, CancellationToken cancellationToken)
 		{
 			if (securities.Length == 0)
 			{
-				logs.AddWarningLog("No instruments.");
+				logs.LogWarning("No instruments.");
 				return Task.CompletedTask;
 			}
 
@@ -31,7 +31,7 @@ namespace StockSharp.Algo.Analytics
 				var volsSeries = new Dictionary<DateTimeOffset, decimal>();
 
 				// get candle storage
-				var candleStorage = storage.GetTimeFrameCandleMessageStorage(security, timeFrame, drive, format);
+				var candleStorage = storage.GetCandleMessageStorage(security, dataType, drive, format);
 
 				foreach (var candle in candleStorage.Load(from, to))
 				{
@@ -49,6 +49,7 @@ namespace StockSharp.Algo.Analytics
 		}
 	}
 }
+
 ```
 
 ## Overview
@@ -57,11 +58,11 @@ This script is designed to draw charts based on the price and volume data of fin
 
 ## `IAnalyticsScript` Interface
 
-The [IAnalyticsScript](xref:StockSharp.Algo.Analytics.IAnalyticsScript) interface ensures that any implementing analytical script will have the [Run](xref:StockSharp.Algo.Analytics.IAnalyticsScript.Run(Ecng.Logging.ILogReceiver,StockSharp.Algo.Analytics.IAnalyticsPanel,StockSharp.Messages.SecurityId[],System.DateTime,System.DateTime,StockSharp.Algo.Storages.IStorageRegistry,StockSharp.Algo.Storages.IMarketDataDrive,StockSharp.Algo.Storages.StorageFormats,System.TimeSpan,System.Threading.CancellationToken)) method, which is necessary for performing the script's analytical operations.
+The [IAnalyticsScript](xref:StockSharp.Algo.Analytics.IAnalyticsScript) interface ensures that any implementing analytical script will have the [Run](xref:StockSharp.Algo.Analytics.IAnalyticsScript.Run(Ecng.Logging.ILogReceiver,StockSharp.Algo.Analytics.IAnalyticsPanel,StockSharp.Messages.SecurityId[],System.DateTime,System.DateTime,StockSharp.Algo.Storages.IStorageRegistry,StockSharp.Algo.Storages.IMarketDataDrive,StockSharp.Algo.Storages.StorageFormats,StockSharp.Messages.DataType,System.Threading.CancellationToken)) method, which is necessary for performing the script's analytical operations.
 
 ### `Run` Method
 
-The [Run](xref:StockSharp.Algo.Analytics.IAnalyticsScript.Run(Ecng.Logging.ILogReceiver,StockSharp.Algo.Analytics.IAnalyticsPanel,StockSharp.Messages.SecurityId[],System.DateTime,System.DateTime,StockSharp.Algo.Storages.IStorageRegistry,StockSharp.Algo.Storages.IMarketDataDrive,StockSharp.Algo.Storages.StorageFormats,System.TimeSpan,System.Threading.CancellationToken)) method is the entry point of an analytical script, where actual data processing and analytical operations are performed.
+The [Run](xref:StockSharp.Algo.Analytics.IAnalyticsScript.Run(Ecng.Logging.ILogReceiver,StockSharp.Algo.Analytics.IAnalyticsPanel,StockSharp.Messages.SecurityId[],System.DateTime,System.DateTime,StockSharp.Algo.Storages.IStorageRegistry,StockSharp.Algo.Storages.IMarketDataDrive,StockSharp.Algo.Storages.StorageFormats,StockSharp.Messages.DataType,System.Threading.CancellationToken)) method is the entry point of an analytical script, where actual data processing and analytical operations are performed.
 
 #### Parameters:
 
@@ -73,7 +74,7 @@ The [Run](xref:StockSharp.Algo.Analytics.IAnalyticsScript.Run(Ecng.Logging.ILogR
 - `storage`: An instance of [IStorageRegistry](xref:StockSharp.Algo.Storages.IStorageRegistry) allowing access to the market data storage.
 - `drive`: Represents [IMarketDataDrive](xref:StockSharp.Algo.Storages.IMarketDataDrive) to specify the location of market data storage.
 - `format`: A [StorageFormats](xref:StockSharp.Algo.Storages.StorageFormats) value indicating the market data format.
-- `timeFrame`: [TimeSpan](xref:System.TimeSpan) indicating the timeframe for the market data, such as 1 hour or 1 day.
+- `dataType`: [DataType](xref:StockSharp.Messages.DataType) describing the requested market data type and its parameters (for example, the candle time-frame).
 - `cancellationToken`: [CancellationToken](xref:System.Threading.CancellationToken) monitoring for cancellation requests.
 
 #### Returns:
@@ -89,7 +90,7 @@ The `ChartDrawScript` class specifically processes market data for each provided
 1. Check for the presence of instruments to process. If none are available, log a warning and complete the task.
 2. Create a line chart and a histogram using the [IAnalyticsPanel.CreateChart](xref:StockSharp.Algo.Analytics.IAnalyticsPanel.CreateChart``2) method.
 3. Iterate through each security and check for cancellation requests.
-4. Get the candle storage using the `storage.GetTimeFrameCandleMessageStorage` method.
+4. Get the candle storage using the `storage.GetCandleMessageStorage` method.
 5. Load candle data within the specified date range.
 6. Fill dictionaries with open time series data, corresponding closing prices, and total volumes.
 7. Draw series data on charts using `lineChart.Append` and `histogramChart.Append` methods.

--- a/en/topics/hydra/analytics/examples/3d_chart.md
+++ b/en/topics/hydra/analytics/examples/3d_chart.md
@@ -47,11 +47,11 @@ namespace StockSharp.Algo.Analytics
 	/// </summary>
 	public class Chart3DScript : IAnalyticsScript
 	{
-		Task IAnalyticsScript.Run(ILogReceiver logs, IAnalyticsPanel panel, SecurityId[] securities, DateTime from, DateTime to, IStorageRegistry storage, IMarketDataDrive drive, StorageFormats format, TimeSpan timeFrame, CancellationToken cancellationToken)
+		Task IAnalyticsScript.Run(ILogReceiver logs, IAnalyticsPanel panel, SecurityId[] securities, DateTime from, DateTime to, IStorageRegistry storage, IMarketDataDrive drive, StorageFormats format, DataType dataType, CancellationToken cancellationToken)
 		{
 			if (securities.Length == 0)
 			{
-				logs.AddWarningLog("No instruments.");
+				logs.LogWarning("No instruments.");
 				return Task.CompletedTask;
 			}
 
@@ -76,14 +76,14 @@ namespace StockSharp.Algo.Analytics
 				x.Add(security.ToStringId());
 
 				// get candle storage
-				var candleStorage = storage.GetTimeFrameCandleMessageStorage(security, timeFrame, drive, format);
+				var candleStorage = storage.GetCandleMessageStorage(security, dataType, drive, format);
 
 				// get available dates for the specified period
 				var dates = candleStorage.GetDates(from, to).ToArray();
 
 				if (dates.Length == 0)
 				{
-					logs.AddWarningLog("no data");
+					logs.LogWarning("no data");
 					return Task.CompletedTask;
 				}
 
@@ -103,6 +103,7 @@ namespace StockSharp.Algo.Analytics
 		}
 	}
 }
+
 ```
 
 ## Script Code on Python
@@ -116,7 +117,6 @@ clr.AddReference("StockSharp.Algo.Analytics")
 clr.AddReference("Ecng.Drawing")
 
 from Ecng.Drawing import DrawStyles
-from System import TimeSpan
 from System.Threading.Tasks import Task
 from StockSharp.Algo.Analytics import IAnalyticsScript
 from storage_extensions import *
@@ -136,7 +136,7 @@ class chart3d_script(IAnalyticsScript):
 		storage,
 		drive,
 		format,
-		time_frame,
+		data_type,
 		cancellation_token
 	):
 		# Check if there are no instruments
@@ -154,18 +154,22 @@ class chart3d_script(IAnalyticsScript):
 		# Create a 2D array for Z values with dimensions: (number of securities) x (number of hours)
 		z = [[0.0 for _ in range(len(y))] for _ in range(len(securities))]
 
-		for i in range(securities.Length):
+		if data_type is None:
+			logs.LogWarning(f"Unsupported data type {data_type}.")
+			return Task.CompletedTask
+
+		message_type = data_type.MessageType
+
+		for i, security in enumerate(securities):
 			# Stop calculation if user cancels script execution
 			if cancellation_token.IsCancellationRequested:
 				break
-
-			security = securities[i]
 
 			# Fill X labels with security identifiers
 			x.append(to_string_id(security))
 
 			# Get candle storage for current security
-			candle_storage = get_tf_candle_storage(storage, security, time_frame, drive, format)
+			candle_storage = get_candle_storage(storage, security, data_type, drive, format)
 
 			# Get available dates for the specified period
 			dates = get_dates(candle_storage, from_date, to_date)
@@ -175,26 +179,20 @@ class chart3d_script(IAnalyticsScript):
 				return Task.CompletedTask
 
 			# Grouping candles by opening time (truncated to the nearest hour) and summing volumes
-			candles = load_tf_candles(candle_storage, from_date, to_date)
+			candles = load_range(candle_storage, message_type, from_date, to_date)
 			by_hours = {}
 			for candle in candles:
-				# Truncate TimeOfDay to the nearest hour
-				tod = candle.OpenTime.TimeOfDay
-				truncated = TimeSpan.FromHours(int(tod.TotalHours))
-				hour = truncated.Hours
-				# Sum volumes for the hour
+				hour = int(candle.OpenTime.TimeOfDay.TotalHours)
 				by_hours[hour] = by_hours.get(hour, 0) + candle.TotalVolume
 
 			# Fill Z values for current security
 			for hour, volume in by_hours.items():
-				# Set volume at position [i, hour] in the 2D array
-				# Ensure hour is within the range of y labels
-				
 				if hour < len(y):
 					z[i][hour] = float(volume)
-					
+
 		# Draw the 3D chart using panel
 		panel.Draw3D(x, y, nx.to2darray(z), "Instruments", "Hours", "Volume")
 
 		return Task.CompletedTask
+
 ```

--- a/en/topics/hydra/analytics/examples/indicators.md
+++ b/en/topics/hydra/analytics/examples/indicators.md
@@ -48,11 +48,11 @@ namespace StockSharp.Algo.Analytics
 	/// </summary>
 	public class IndicatorScript : IAnalyticsScript
 	{
-		Task IAnalyticsScript.Run(ILogReceiver logs, IAnalyticsPanel panel, SecurityId[] securities, DateTime from, DateTime to, IStorageRegistry storage, IMarketDataDrive drive, StorageFormats format, TimeSpan timeFrame, CancellationToken cancellationToken)
+		Task IAnalyticsScript.Run(ILogReceiver logs, IAnalyticsPanel panel, SecurityId[] securities, DateTime from, DateTime to, IStorageRegistry storage, IMarketDataDrive drive, StorageFormats format, DataType dataType, CancellationToken cancellationToken)
 		{
 			if (securities.Length == 0)
 			{
-				logs.AddWarningLog("No instruments.");
+				logs.LogWarning("No instruments.");
 				return Task.CompletedTask;
 			}
 
@@ -73,13 +73,13 @@ namespace StockSharp.Algo.Analytics
 				var roc = new RateOfChange();
 
 				// get candle storage
-				var candleStorage = storage.GetTimeFrameCandleMessageStorage(security, timeFrame, drive, format);
+				var candleStorage = storage.GetCandleMessageStorage(security, dataType, drive, format);
 
 				foreach (var candle in candleStorage.Load(from, to))
 				{
 					// fill series
 					candlesSeries[candle.OpenTime] = candle.ClosePrice;
-					indicatorSeries[candle.OpenTime] = roc.Process(candle).GetValue<decimal>();
+					indicatorSeries[candle.OpenTime] = roc.Process(candle).ToDecimal();
 				}
 
 				// draw series on chart
@@ -91,6 +91,7 @@ namespace StockSharp.Algo.Analytics
 		}
 	}
 }
+
 ```
 
 ## Script Code on Python
@@ -104,7 +105,6 @@ clr.AddReference("StockSharp.Algo.Analytics")
 clr.AddReference("Ecng.Drawing")
 
 from Ecng.Drawing import DrawStyles
-from System import TimeSpan
 from System.Threading.Tasks import Task
 from StockSharp.Algo.Analytics import IAnalyticsScript
 from StockSharp.Algo.Indicators import ROC
@@ -115,7 +115,7 @@ from indicator_extensions import *
 
 # The analytic script, using indicator ROC.
 class indicator_script(IAnalyticsScript):
-	def Run(self, logs, panel, securities, from_date, to_date, storage, drive, format, time_frame, cancellation_token):
+	def Run(self, logs, panel, securities, from_date, to_date, storage, drive, format, data_type, cancellation_token):
 		if not securities:
 			logs.LogWarning("No instruments.")
 			return Task.CompletedTask
@@ -123,6 +123,12 @@ class indicator_script(IAnalyticsScript):
 		# creating 2 panes for candles and indicator series
 		candle_chart = create_chart(panel, datetime, float)
 		indicator_chart = create_chart(panel, datetime, float)
+
+		if data_type is None:
+			logs.LogWarning(f"Unsupported data type {data_type}.")
+			return Task.CompletedTask
+
+		message_type = data_type.MessageType
 
 		for security in securities:
 			# stop calculation if user cancel script execution
@@ -136,12 +142,12 @@ class indicator_script(IAnalyticsScript):
 			roc = ROC()
 
 			# get candle storage
-			candle_storage = get_tf_candle_storage(storage, security, time_frame, drive, format)
+			candle_storage = get_candle_storage(storage, security, data_type, drive, format)
 
-			for candle in load_tf_candles(candle_storage, from_date, to_date):
+			for candle in load_range(candle_storage, message_type, from_date, to_date):
 				# fill series
 				candles_series[candle.OpenTime] = candle.ClosePrice
-				indicator_series[candle.OpenTime] = to_decimal(process_with_candle(roc, candle))
+				indicator_series[candle.OpenTime] = to_decimal(process_candle(roc, candle))
 
 			# draw series on chart
 			candle_chart.Append(
@@ -156,4 +162,5 @@ class indicator_script(IAnalyticsScript):
 			)
 
 		return Task.CompletedTask
+
 ```

--- a/en/topics/hydra/analytics/examples/intraday_volume.md
+++ b/en/topics/hydra/analytics/examples/intraday_volume.md
@@ -36,11 +36,11 @@ namespace StockSharp.Algo.Analytics
 	/// </summary>
 	public class TimeVolumeScript : IAnalyticsScript
 	{
-		Task IAnalyticsScript.Run(ILogReceiver logs, IAnalyticsPanel panel, SecurityId[] securities, DateTime from, DateTime to, IStorageRegistry storage, IMarketDataDrive drive, StorageFormats format, TimeSpan timeFrame, CancellationToken cancellationToken)
+		Task IAnalyticsScript.Run(ILogReceiver logs, IAnalyticsPanel panel, SecurityId[] securities, DateTime from, DateTime to, IStorageRegistry storage, IMarketDataDrive drive, StorageFormats format, DataType dataType, CancellationToken cancellationToken)
 		{
 			if (securities.Length == 0)
 			{
-				logs.AddWarningLog("No instruments.");
+				logs.LogWarning("No instruments.");
 				return Task.CompletedTask;
 			}
 
@@ -48,14 +48,14 @@ namespace StockSharp.Algo.Analytics
 			var security = securities.First();
 
 			// get candle storage
-			var candleStorage = storage.GetTimeFrameCandleMessageStorage(security, timeFrame, drive, format);
+			var candleStorage = storage.GetCandleMessageStorage(security, dataType, drive, format);
 
 			// get available dates for the specified period
 			var dates = candleStorage.GetDates(from, to).ToArray();
 
 			if (dates.Length == 0)
 			{
-				logs.AddWarningLog("no data");
+				logs.LogWarning("no data");
 				return Task.CompletedTask;
 			}
 
@@ -77,6 +77,7 @@ namespace StockSharp.Algo.Analytics
 		}
 	}
 }
+
 ```
 
 ## Script Code on Python
@@ -110,7 +111,7 @@ class time_volume_script(IAnalyticsScript):
 		storage,
 		drive,
 		format,
-		time_frame,
+		data_type,
 		cancellation_token
 	):
 		# Check if there are no instruments
@@ -121,8 +122,14 @@ class time_volume_script(IAnalyticsScript):
 		# Script can process only 1 instrument
 		security = securities[0]
 
+		if data_type is None:
+			logs.LogWarning(f"Unsupported data type {data_type}.")
+			return Task.CompletedTask
+
+		message_type = data_type.MessageType
+
 		# Get candle storage
-		candle_storage = get_tf_candle_storage(storage, security, time_frame, drive, format)
+		candle_storage = get_candle_storage(storage, security, data_type, drive, format)
 
 		# Get available dates for the specified period
 		dates = get_dates(candle_storage, from_date, to_date)
@@ -132,13 +139,11 @@ class time_volume_script(IAnalyticsScript):
 			return Task.CompletedTask
 
 		# Grouping candles by opening time (hourly truncation) and summing their volumes
-		candles = load_tf_candles(candle_storage, from_date, to_date)
+		candles = load_range(candle_storage, message_type, from_date, to_date)
 		rows = {}
 		for candle in candles:
-			# Truncate TimeOfDay to the nearest hour
 			time_of_day = candle.OpenTime.TimeOfDay
 			truncated = TimeSpan.FromHours(int(time_of_day.TotalHours))
-			# Sum volumes for each truncated hour
 			rows[truncated] = rows.get(truncated, 0) + candle.TotalVolume
 
 		# Put our calculations into grid
@@ -151,4 +156,5 @@ class time_volume_script(IAnalyticsScript):
 		grid.SetSort("Volume", False)
 
 		return Task.CompletedTask
+
 ```

--- a/en/topics/hydra/analytics/examples/largest_candles.md
+++ b/en/topics/hydra/analytics/examples/largest_candles.md
@@ -33,11 +33,11 @@ namespace StockSharp.Algo.Analytics
 	/// </summary>
 	public class BiggestCandleScript : IAnalyticsScript
 	{
-		Task IAnalyticsScript.Run(ILogReceiver logs, IAnalyticsPanel panel, SecurityId[] securities, DateTime from, DateTime to, IStorageRegistry storage, IMarketDataDrive drive, StorageFormats format, TimeSpan timeFrame, CancellationToken cancellationToken)
+		Task IAnalyticsScript.Run(ILogReceiver logs, IAnalyticsPanel panel, SecurityId[] securities, DateTime from, DateTime to, IStorageRegistry storage, IMarketDataDrive drive, StorageFormats format, DataType dataType, CancellationToken cancellationToken)
 		{
 			if (securities.Length == 0)
 			{
-				logs.AddWarningLog("No instruments.");
+				logs.LogWarning("No instruments.");
 				return Task.CompletedTask;
 			}
 
@@ -54,7 +54,7 @@ namespace StockSharp.Algo.Analytics
 					break;
 
 				// get candle storage
-				var candleStorage = storage.GetTimeFrameCandleMessageStorage(security, timeFrame, drive, format);
+				var candleStorage = storage.GetCandleMessageStorage(security, dataType, drive, format);
 
 				var allCandles = candleStorage.Load(from, to).ToArray();
 
@@ -77,6 +77,7 @@ namespace StockSharp.Algo.Analytics
 		}
 	}
 }
+
 ```
 
 ## Script Code on Python
@@ -90,7 +91,6 @@ clr.AddReference("StockSharp.Algo.Analytics")
 clr.AddReference("Ecng.Drawing")
 
 from Ecng.Drawing import DrawStyles
-from System import TimeSpan
 from System.Threading.Tasks import Task
 from StockSharp.Algo.Analytics import IAnalyticsScript
 from storage_extensions import *
@@ -100,7 +100,7 @@ from indicator_extensions import *
 
 # The analytic script, shows biggest candle (by volume and by length) for specified securities.
 class biggest_candle_script(IAnalyticsScript):
-	def Run(self, logs, panel, securities, from_date, to_date, storage, drive, format, time_frame, cancellation_token):
+	def Run(self, logs, panel, securities, from_date, to_date, storage, drive, format, data_type, cancellation_token):
 		if not securities:
 			logs.LogWarning("No instruments.")
 			return Task.CompletedTask
@@ -111,14 +111,20 @@ class biggest_candle_script(IAnalyticsScript):
 		big_price_candles = []
 		big_vol_candles = []
 
+		if data_type is None:
+			logs.LogWarning(f"Unsupported data type {data_type}.")
+			return Task.CompletedTask
+
+		message_type = data_type.MessageType
+
 		for security in securities:
 			# stop calculation if user cancel script execution
 			if cancellation_token.IsCancellationRequested:
 				break
 
 			# get candle storage
-			candle_storage = get_tf_candle_storage(storage, security, time_frame, drive, format)
-			all_candles = load_tf_candles(candle_storage, from_date, to_date)
+			candle_storage = get_candle_storage(storage, security, data_type, drive, format)
+			all_candles = load_range(candle_storage, message_type, from_date, to_date)
 
 			if len(all_candles) > 0:
 				# first orders by volume desc will be our biggest candle
@@ -147,4 +153,5 @@ class biggest_candle_script(IAnalyticsScript):
 		)
 
 		return Task.CompletedTask
+
 ```

--- a/en/topics/hydra/analytics/examples/normalization.md
+++ b/en/topics/hydra/analytics/examples/normalization.md
@@ -42,11 +42,11 @@ namespace StockSharp.Algo.Analytics
 	/// </summary>
 	public class NormalizePriceScript : IAnalyticsScript
 	{
-		Task IAnalyticsScript.Run(ILogReceiver logs, IAnalyticsPanel panel, SecurityId[] securities, DateTime from, DateTime to, IStorageRegistry storage, IMarketDataDrive drive, StorageFormats format, TimeSpan timeFrame, CancellationToken cancellationToken)
+		Task IAnalyticsScript.Run(ILogReceiver logs, IAnalyticsPanel panel, SecurityId[] securities, DateTime from, DateTime to, IStorageRegistry storage, IMarketDataDrive drive, StorageFormats format, DataType dataType, CancellationToken cancellationToken)
 		{
 			if (securities.Length == 0)
 			{
-				logs.AddWarningLog("No instruments.");
+				logs.LogWarning("No instruments.");
 				return Task.CompletedTask;
 			}
 
@@ -61,7 +61,7 @@ namespace StockSharp.Algo.Analytics
 				var series = new Dictionary<DateTimeOffset, decimal>();
 
 				// get candle storage
-				var candleStorage = storage.GetTimeFrameCandleMessageStorage(security, timeFrame, drive, format);
+				var candleStorage = storage.GetCandleMessageStorage(security, dataType, drive, format);
 
 				decimal? firstClose = null;
 
@@ -81,6 +81,7 @@ namespace StockSharp.Algo.Analytics
 		}
 	}
 }
+
 ```
 
 ## Script Code on Python
@@ -94,7 +95,6 @@ clr.AddReference("StockSharp.Algo.Analytics")
 clr.AddReference("Ecng.Drawing")
 
 from Ecng.Drawing import DrawStyles
-from System import TimeSpan
 from System.Threading.Tasks import Task
 from StockSharp.Algo.Analytics import IAnalyticsScript
 from storage_extensions import *
@@ -104,12 +104,18 @@ from indicator_extensions import *
 
 # The analytic script, normalize securities close prices and shows on same chart.
 class normalize_price_script(IAnalyticsScript):
-	def Run(self, logs, panel, securities, from_date, to_date, storage, drive, format, time_frame, cancellation_token):
+	def Run(self, logs, panel, securities, from_date, to_date, storage, drive, format, data_type, cancellation_token):
 		if not securities:
 			logs.LogWarning("No instruments.")
 			return Task.CompletedTask
 
 		chart = create_chart(panel, datetime, float)
+
+		if data_type is None:
+			logs.LogWarning(f"Unsupported data type {data_type}.")
+			return Task.CompletedTask
+
+		message_type = data_type.MessageType
 
 		for security in securities:
 			# stop calculation if user cancel script execution
@@ -119,11 +125,11 @@ class normalize_price_script(IAnalyticsScript):
 			series = {}
 
 			# get candle storage
-			candle_storage = get_tf_candle_storage(storage, security, time_frame, drive, format)
+			candle_storage = get_candle_storage(storage, security, data_type, drive, format)
 
 			first_close = None
 
-			for candle in load_tf_candles(candle_storage, from_date, to_date):
+			for candle in load_range(candle_storage, message_type, from_date, to_date):
 				if first_close is None:
 					first_close = candle.ClosePrice
 
@@ -134,4 +140,5 @@ class normalize_price_script(IAnalyticsScript):
 			chart.Append(to_string_id(security), list(series.keys()), list(series.values()))
 
 		return Task.CompletedTask
+
 ```

--- a/ru/topics/hydra/analytics/examples/pearson_correlation.md
+++ b/ru/topics/hydra/analytics/examples/pearson_correlation.md
@@ -54,11 +54,11 @@ namespace StockSharp.Algo.Analytics
 	/// </summary>
 	public class PearsonCorrelationScript : IAnalyticsScript
 	{
-		Task IAnalyticsScript.Run(ILogReceiver logs, IAnalyticsPanel panel, SecurityId[] securities, DateTime from, DateTime to, IStorageRegistry storage, IMarketDataDrive drive, StorageFormats format, TimeSpan timeFrame, CancellationToken cancellationToken)
+		Task IAnalyticsScript.Run(ILogReceiver logs, IAnalyticsPanel panel, SecurityId[] securities, DateTime from, DateTime to, IStorageRegistry storage, IMarketDataDrive drive, StorageFormats format, DataType dataType, CancellationToken cancellationToken)
 		{
 			if (securities.Length == 0)
 			{
-				logs.AddWarningLog("No instruments.");
+				logs.LogWarning("No instruments.");
 				return Task.CompletedTask;
 			}
 
@@ -71,14 +71,14 @@ namespace StockSharp.Algo.Analytics
 					break;
 
 				// get candle storage
-				var candleStorage = storage.GetTimeFrameCandleMessageStorage(security, timeFrame, drive, format);
+				var candleStorage = storage.GetCandleMessageStorage(security, dataType, drive, format);
 
 				// get closing prices
 				var prices = candleStorage.Load(from, to).Select(c => (double)c.ClosePrice).ToArray();
 
 				if (prices.Length == 0)
 				{
-					logs.AddWarningLog("No data for {0}", security);
+					logs.LogWarning("No data for {0}", security);
 					return Task.CompletedTask;
 				}
 
@@ -107,6 +107,7 @@ namespace StockSharp.Algo.Analytics
 		}
 	}
 }
+
 ```
 
 ## Код скрипта на Python
@@ -120,7 +121,6 @@ clr.AddReference("StockSharp.Algo.Analytics")
 clr.AddReference("Ecng.Drawing")
 
 from Ecng.Drawing import DrawStyles
-from System import TimeSpan
 from System.Threading.Tasks import Task
 from StockSharp.Algo.Analytics import IAnalyticsScript
 from storage_extensions import *
@@ -144,7 +144,7 @@ class pearson_correlation_script(IAnalyticsScript):
 		storage,
 		drive,
 		format,
-		time_frame,
+		data_type,
 		cancellation_token
 	):
 		if not securities:
@@ -153,16 +153,22 @@ class pearson_correlation_script(IAnalyticsScript):
 
 		closes = []
 
+		if data_type is None:
+			logs.LogWarning(f"Unsupported data type {data_type}.")
+			return Task.CompletedTask
+
+		message_type = data_type.MessageType
+
 		for security in securities:
 			# stop calculation if user cancel script execution
 			if cancellation_token.IsCancellationRequested:
 				break
 
 			# get candle storage
-			candle_storage = get_tf_candle_storage(storage, security, time_frame, drive, format)
+			candle_storage = get_candle_storage(storage, security, data_type, drive, format)
 
 			# get closing prices
-			prices = [float(c.ClosePrice) for c in load_tf_candles(candle_storage, from_date, to_date)]
+			prices = [float(c.ClosePrice) for c in load_range(candle_storage, message_type, from_date, to_date)]
 
 			if len(prices) == 0:
 				logs.LogWarning("No data for {0}", security)
@@ -173,10 +179,10 @@ class pearson_correlation_script(IAnalyticsScript):
 		# all arrays must be the same length, so truncate longer ones
 		min_length = min(len(arr) for arr in closes)
 		closes = [arr[:min_length] for arr in closes]
-		
+
 		# convert list or array into 2D array
 		array2d = nx.to2darray(closes)
-		
+
 		# calculating correlation using NumSharp
 		np_array = np.array(array2d)
 		matrix = np.corrcoef(np_array)
@@ -186,4 +192,5 @@ class pearson_correlation_script(IAnalyticsScript):
 		panel.DrawHeatmap(ids, ids, nx.tosystemarray(matrix))
 
 		return Task.CompletedTask
+
 ```

--- a/ru/topics/hydra/analytics/examples/volume_profile.md
+++ b/ru/topics/hydra/analytics/examples/volume_profile.md
@@ -41,11 +41,11 @@ namespace StockSharp.Algo.Analytics
 	/// </summary>
 	public class PriceVolumeScript : IAnalyticsScript
 	{
-		Task IAnalyticsScript.Run(ILogReceiver logs, IAnalyticsPanel panel, SecurityId[] securities, DateTime from, DateTime to, IStorageRegistry storage, IMarketDataDrive drive, StorageFormats format, TimeSpan timeFrame, CancellationToken cancellationToken)
+		Task IAnalyticsScript.Run(ILogReceiver logs, IAnalyticsPanel panel, SecurityId[] securities, DateTime from, DateTime to, IStorageRegistry storage, IMarketDataDrive drive, StorageFormats format, DataType dataType, CancellationToken cancellationToken)
 		{
 			if (securities.Length == 0)
 			{
-				logs.AddWarningLog("No instruments.");
+				logs.LogWarning("No instruments.");
 				return Task.CompletedTask;
 			}
 
@@ -53,14 +53,14 @@ namespace StockSharp.Algo.Analytics
 			var security = securities.First();
 
 			// get candle storage
-			var candleStorage = storage.GetTimeFrameCandleMessageStorage(security, timeFrame, drive, format);
+			var candleStorage = storage.GetCandleMessageStorage(security, dataType, drive, format);
 
 			// get available dates for the specified period
 			var dates = candleStorage.GetDates(from, to).ToArray();
 
 			if (dates.Length == 0)
 			{
-				logs.AddWarningLog("no data");
+				logs.LogWarning("no data");
 				return Task.CompletedTask;
 			}
 
@@ -77,6 +77,7 @@ namespace StockSharp.Algo.Analytics
 		}
 	}
 }
+
 ```
 
 ## Код скрипта на Python
@@ -90,7 +91,6 @@ clr.AddReference("StockSharp.Algo.Analytics")
 clr.AddReference("Ecng.Drawing")
 
 from Ecng.Drawing import DrawStyles
-from System import TimeSpan
 from System.Threading.Tasks import Task
 from StockSharp.Algo.Analytics import IAnalyticsScript
 from storage_extensions import *
@@ -110,7 +110,7 @@ class price_volume_script(IAnalyticsScript):
 		storage,
 		drive,
 		format,
-		time_frame,
+		data_type,
 		cancellation_token
 	):
 		# Check if there are no instruments
@@ -121,8 +121,14 @@ class price_volume_script(IAnalyticsScript):
 		# Script can process only 1 instrument
 		security = securities[0]
 
+		if data_type is None:
+			logs.LogWarning(f"Unsupported data type {data_type}.")
+			return Task.CompletedTask
+
+		message_type = data_type.MessageType
+
 		# Get candle storage
-		candle_storage = get_tf_candle_storage(storage, security, time_frame, drive, format)
+		candle_storage = get_candle_storage(storage, security, data_type, drive, format)
 
 		# Get available dates for the specified period
 		dates = get_dates(candle_storage, from_date, to_date)
@@ -132,7 +138,7 @@ class price_volume_script(IAnalyticsScript):
 			return Task.CompletedTask
 
 		# Grouping candles by middle price and summing their volumes
-		candles = load_tf_candles(candle_storage, from_date, to_date)
+		candles = load_range(candle_storage, message_type, from_date, to_date)
 		rows_dict = {}
 		for candle in candles:
 			# Calculate middle price of the candle
@@ -145,4 +151,5 @@ class price_volume_script(IAnalyticsScript):
 		chart.Append(to_string_id(security), list(rows_dict.keys()), list(rows_dict.values()), DrawStyles.Histogram)
 
 		return Task.CompletedTask
+
 ```


### PR DESCRIPTION
## Summary
- switch the Hydra create-your-own script documentation to the new DataType-based storage access pattern and refresh the walkthrough text
- sync all English analytics example snippets (C# and Python) with the latest StockSharp repository versions that consume DataType
- mirror the same DataType-focused updates in the Russian Hydra analytics example docs for parity

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e62edf314c83239f4bec8bd16f4c20